### PR TITLE
Allow pass own version of Postgres binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,28 @@ public EmbeddedPostgreSQLRule pg = new EmbeddedPostgreSQLRule();
 
 This simply has JUnit manage an instance of EmbeddedPostgreSQLRule (start, stop). You can then use this to get a DataSource with: `pg.getEmbeddedPostgreSQL().getPostgresDatabase();`  
 
-Additionally you may use the [`EmbeddedPostgreSQL`](src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgreSQL.java) class directly by manually starting and stopping the instance; see [`EmbeddedPostgreSQLTest`](src/test/java/com/opentable/db/postgres/embedded/EmbeddedPostgreSQLTest.java) for an example.  
+Additionally you may use the [`EmbeddedPostgreSQL`](src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgreSQL.java) class directly by manually starting and stopping the instance; see [`EmbeddedPostgreSQLTest`](src/test/java/com/opentable/db/postgres/embedded/EmbeddedPostgreSQLTest.java) for an example.
+
+## Postgres version
+
+The JAR file contains bundled version of Postgres. You can pass different Postgres version by implementing [`PgBinaryResolver`](src/main/java/com/opentable/db/postgres/embedded/PgBinaryResolver.java).
+
+Example:
+```java
+class ClasspathBinaryResolver implements PgBinaryResolver{
+    public InputStream getPgBinary(String system, String machineHardware) throws IOException{
+        ClassPathResource resource = new ClassPathResource(format("pgsql/postgresql-%s-%s.tbz", system, machineHardware));
+        return resource.getInputStream();
+    }
+}
+
+EmbeddedPostgreSQL
+            .builder()
+            .setPgBinaryResolver(new ClasspathBinaryResolver())
+            .start();
+
+```
+
 
 ----
 Copyright (C) 2014 OpenTable, Inc

--- a/src/main/java/com/opentable/db/postgres/embedded/BundledPostgresBinaryResolver.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/BundledPostgresBinaryResolver.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.opentable.db.postgres.embedded;
+
+import static java.lang.String.format;
+
+import java.io.InputStream;
+
+/**
+ * Resolves pre-bundled binaries from within the JAR file.
+ */
+final class BundledPostgresBinaryResolver implements PgBinaryResolver {
+
+    @Override
+    public InputStream getPgBinary(String system, String machineHardware) {
+        return EmbeddedPostgreSQL.class.getResourceAsStream(format("/postgresql-%s-%s.tbz", system, machineHardware));
+    }
+
+}

--- a/src/main/java/com/opentable/db/postgres/embedded/PgBinaryResolver.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/PgBinaryResolver.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.opentable.db.postgres.embedded;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * A strategy for resolving PostgreSQL binaries.
+ *
+ * @see BundledPostgresBinaryResolver
+ */
+public interface PgBinaryResolver {
+
+    /**
+     * Returns an input stream with the postgress binary for the given
+     * systen and hardware architecture.
+     * @param system a system identification (Darwin, Linux...)
+     * @param machineHardware a machine hardware architecture (x86_64...)
+     * @return the binary
+     */
+    InputStream getPgBinary(String system, String machineHardware) throws IOException;
+}


### PR DESCRIPTION
EmbeddedPostgreSQL starts the bundled version of Postgres. This is not practical
and sometimes it's real show stopper when different version is required. This
patch allows pass own version of Postgress binary via PgBinaryResolver (see the
default implementation BundledPostgresBinaryResolver). It's a
strategy used by EmbeddedPostgreSQL.