### PR TITLE
Windows support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.11</version>
+    </dependency>
+
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/repack-postgres.sh
+++ b/repack-postgres.sh
@@ -6,10 +6,12 @@ cd `dirname $0`
 PACKDIR=$(mktemp -d -t wat.XXXXXX)
 LINUX_DIST=dist/postgresql-$VERSION-linux-x64-binaries.tar.gz
 OSX_DIST=dist/postgresql-$VERSION-osx-binaries.zip
+WINDOWS_DIST=dist/postgresql-$VERSION-win-binaries.zip
 
 mkdir -p dist/ target/generated-resources/
 [ -e $LINUX_DIST ] || wget -O $LINUX_DIST "http://get.enterprisedb.com/postgresql/postgresql-$VERSION-linux-x64-binaries.tar.gz"
 [ -e $OSX_DIST ] || wget -O $OSX_DIST "http://get.enterprisedb.com/postgresql/postgresql-$VERSION-osx-binaries.zip"
+[ -e $WINDOWS_DIST ] || wget -O $WINDOWS_DIST "http://get.enterprisedb.com/postgresql/postgresql-$VERSION-windows-x64-binaries.zip"
 
 tar xzf $LINUX_DIST -C $PACKDIR
 pushd $PACKDIR/pgsql
@@ -36,6 +38,22 @@ tar cjf $OLDPWD/target/generated-resources/postgresql-Darwin-x86_64.tbz \
   bin/initdb \
   bin/pg_ctl \
   bin/postgres
+popd
+
+rm -fr $PACKDIR && mkdir -p $PACKDIR
+
+unzip -q -d $PACKDIR $WINDOWS_DIST
+pushd $PACKDIR/pgsql
+tar cjf $OLDPWD/target/generated-resources/postgresql-Windows-x86_64.tbz \
+  share \
+  lib/iconv.lib \
+  lib/libxml2.lib \
+  lib/ssleay32.lib \
+  lib/ssleay32MD.lib \
+  lib/*.dll \
+  bin/initdb.exe \
+  bin/pg_ctl.exe \
+  bin/postgres.exe
 popd
 
 rm -rf $PACKDIR

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -485,7 +485,8 @@ public class EmbeddedPostgres implements AutoCloseable, Closeable
                 if (entry.isFile()) {
                     byte[] content = new byte[(int) entry.getSize()];
                     offset = 0;
-                    tarIn.read(content, offset, content.length - offset);
+                    int read = tarIn.read(content, offset, content.length - offset);
+                    Preconditions.checkState(read != -1, "could not read %s", individualFile);
                     mkdirs(fsObject.getParentFile());
                     outputFile = new FileOutputStream(fsObject);
                     IOUtils.write(content, outputFile);

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -455,8 +455,9 @@ public class EmbeddedPostgres implements AutoCloseable, Closeable
      * @return Current machine architecture string.
      */
     private static String getArchitecture(){
-        if (!SystemUtils.IS_OS_WINDOWS)
+        if (!SystemUtils.IS_OS_WINDOWS) {
             return system("uname", "-m").get(0);
+        }
 
         return "amd64".equals(SystemUtils.OS_ARCH) || SystemUtils.OS_ARCH == null ? "x86_64" : SystemUtils.OS_ARCH;
     }
@@ -472,7 +473,7 @@ public class EmbeddedPostgres implements AutoCloseable, Closeable
                 final FileInputStream fin = new FileInputStream(tbzPath);
                 final BufferedInputStream in = new BufferedInputStream(fin);
                 final ByteArrayOutputStream tarOut = new ByteArrayOutputStream();
-                final BZip2CompressorInputStream bzIn = new BZip2CompressorInputStream(in);
+                final BZip2CompressorInputStream bzIn = new BZip2CompressorInputStream(in)
         ) {
             final byte[] buffer = new byte[4096];
             int n;

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -58,7 +58,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
-public class EmbeddedPostgres implements Closeable
+public class EmbeddedPostgres implements AutoCloseable, Closeable
 {
     private static final Logger LOG = LoggerFactory.getLogger(EmbeddedPostgres.class);
     private static final String JDBC_FORMAT = "jdbc:postgresql://localhost:%s/%s?user=%s";
@@ -340,7 +340,8 @@ public class EmbeddedPostgres implements Closeable
 
     private String pgBin(String binaryName)
     {
-        return new File(pgDir, "bin/" + binaryName).getPath();
+        final String extension = SystemUtils.IS_OS_WINDOWS ? ".exe" : "";
+        return new File(pgDir, "bin/" + binaryName + extension).getPath();
     }
 
     public static EmbeddedPostgres start() throws IOException

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -33,7 +33,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.ServerSocket;
 import java.net.UnknownHostException;
 import java.nio.channels.FileLock;


### PR DESCRIPTION
Removed dependency on uname (on Windows) and tar binaries.
Added 64 bit windows binary fetch to repack-postgres.sh script.
Tested on 64bit Windows 10.