### PR TITLE
Use Verify instead Preconditions for assertions

### DIFF
--- a/src/main/java/com/opentable/db/postgres/junit/SingleInstancePostgresRule.java
+++ b/src/main/java/com/opentable/db/postgres/junit/SingleInstancePostgresRule.java
@@ -19,6 +19,7 @@ import java.sql.SQLException;
 
 import com.google.common.base.Preconditions;
 
+import com.google.common.base.Verify;
 import org.junit.rules.ExternalResource;
 
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
@@ -41,7 +42,7 @@ public class SingleInstancePostgresRule extends ExternalResource
     public EmbeddedPostgres getEmbeddedPostgres()
     {
         EmbeddedPostgres epg = this.epg;
-        Preconditions.checkState(epg != null, "JUnit test not started yet!");
+        Verify.verify(epg != null, "JUnit test not started yet!");
         return epg;
     }
 


### PR DESCRIPTION
This is a rather opinionated PR, but I stumbled upon on some errors during running Postgres in the embedded mode and thought that the exception naming may be improved.

The Google Guava team advises to use verification checks for cases when developers want to verify that underlined API behaves correctly. See [ConditionalFailuresExplained](https://github.com/google/guava/wiki/ConditionalFailuresExplained).

This should help users to diagnose problems more easily, because they get a more meaningful `VerifyException` rather than `IllegalStateException`, which implies that some verification checks have failed.