### PR TITLE
Treating hard-links as soft-links instead of files. This avoids trigg…

### DIFF
--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -495,7 +495,7 @@ public class EmbeddedPostgres implements Closeable
                 final String individualFile = entry.getName();
                 final File fsObject = new File(targetDir + "/" + individualFile);
 
-                if (entry.isSymbolicLink()) {
+                if (entry.isSymbolicLink() || entry.isLink()) {
                     Path target = FileSystems.getDefault().getPath(entry.getLinkName());
                     Files.createSymbolicLink(fsObject.toPath(), target);
                 } else if (entry.isFile()) {


### PR DESCRIPTION
While trying to untar a PostgreSQL tar file containing hard-links, the following precondition failed:
```java
} else if (entry.isFile()) {
  byte[] content = new byte[(int) entry.getSize()];
  int read = tarIn.read(content, 0, content.length);
  Preconditions.checkState(read != -1, "could not read %s", individualFile);
```
I bumped into this while trying to use a tar I made, using the output files  `brew install postgis` generated at '/usr/local/Cellar/postgis/' in a Mac.
```
tar -cvpJLf ~/postgres-postgis.tar.xz bin include lib share
```
Tar file attached (due to GitHub limitations, a zip containing the tar)
[postgres-postgis.tar.xz.zip](https://github.com/opentable/otj-pg-embedded/files/324139/postgres-postgis.tar.xz.zip)