### PR TITLE
Removes ability for remote clients to connect to PG

### DIFF
--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -206,7 +206,7 @@ public class EmbeddedPostgres implements Closeable
     {
         final List<String> initOptions = Lists.newArrayList(
                 "-p", Integer.toString(port),
-                "-i", "-F"
+                "-F"
         );
 
         for (final Entry<String, String> config : postgresConfig.entrySet())


### PR DESCRIPTION
This change keeps the `-i` option from being passed to `postgres` by `pg_ctl`.
The `-i` option [allows remote clients](https://www.postgresql.org/docs/9.5/static/app-postgres.html) to connect to Postgres via TCP/IP.

On OS X, this results in a popup asking if the firewall should allow the `postgres` process to accept connections. This can be mildly to majorly annoying, depending on the size and architecture of the test suite.

I'm hoping that since this is an embedded Postgres instance meant for testing, the `-i` option can be completely removed. If not, I'd be happy to submit a PR that accepts a boolean for whether `EmbeddedPostgres` should allow remote clients to connect.