### PR TITLE
Continue to use the old default, but allow the builder to inject a di…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.10.1
+------
+* add `setPGStartupWait` method to builder to override the default time (10 seconds) for
+waiting for Postgres to start up before throwing an exception.
+
 0.10.0
 ------
 

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -457,7 +457,7 @@ public class EmbeddedPostgres implements Closeable
         }
 
         public Builder setPGStartupWait(Duration pgStartupWait) {
-            if (pgStartupWait.isNegative()) {
+            if (pgStartupWait != null && pgStartupWait.isNegative()) {
                 pgStartupWait = null;
             }
             Objects.requireNonNull(pgStartupWait);

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -457,10 +457,11 @@ public class EmbeddedPostgres implements Closeable
         }
 
         public Builder setPGStartupWait(Duration pgStartupWait) {
-            if (pgStartupWait != null && pgStartupWait.isNegative()) {
-                pgStartupWait = null;
-            }
             Objects.requireNonNull(pgStartupWait);
+            if (pgStartupWait.isNegative()) {
+               throw new IllegalArgumentException("Negative durations are not permitted.");
+            }
+
             this.pgStartupWait = pgStartupWait;
             return this;
         }

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -82,7 +82,7 @@ public class EmbeddedPostgres implements Closeable
     private static final String PG_STOP_MODE = "fast";
     private static final String PG_STOP_WAIT_S = "5";
     private static final String PG_SUPERUSER = "postgres";
-    private static final Duration DEFAULT_PG_STARTUP_WAIT = Duration.ofMillis(10 * 1000);
+    private static final Duration DEFAULT_PG_STARTUP_WAIT = Duration.ofSeconds(10);
     private static final String LOCK_FILE_NAME = "epg-lock";
 
     private final File pgDir;


### PR DESCRIPTION
…fferent time. Also, switch to using Duration.

This is a cleaner (IMO) version of a submitted PR - I saw no reason to have an independent wait