### PR TITLE
Support injecting EmbeddedPostgres.Builder in PreparedDbProvider

### DIFF
--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -535,13 +535,18 @@ public class EmbeddedPostgres implements Closeable
         }
 
         public EmbeddedPostgres start() throws IOException {
-            if (builderPort == 0)
+            int port = builderPort;
+            if (port == 0)
             {
-                builderPort = detectPort();
+                port = detectPort();
             }
-            if (builderDataDirectory == null) {
-                builderDataDirectory = Files.createTempDirectory("epg").toFile();
+            File dataDirectory = builderDataDirectory;
+            if (dataDirectory == null) {
+                dataDirectory = Files.createTempDirectory("epg").toFile();
             }
+            Map<String, String> startConfig = new HashMap<>();
+            startConfig.putAll(this.config);
+            Map<String, String> localeConfig = new HashMap<>();
             return new EmbeddedPostgres(parentDirectory, builderDataDirectory, builderCleanDataDirectory, config, localeConfig, builderPort, connectConfig, pgBinaryResolver, errRedirector, outRedirector, pgStartupWait);
         }
     }

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -544,10 +544,18 @@ public class EmbeddedPostgres implements Closeable
             if (dataDirectory == null) {
                 dataDirectory = Files.createTempDirectory("epg").toFile();
             }
-            Map<String, String> startConfig = new HashMap<>();
-            startConfig.putAll(this.config);
-            Map<String, String> localeConfig = new HashMap<>();
-            return new EmbeddedPostgres(parentDirectory, builderDataDirectory, builderCleanDataDirectory, config, localeConfig, builderPort, connectConfig, pgBinaryResolver, errRedirector, outRedirector, pgStartupWait);
+            return new EmbeddedPostgres(parentDirectory, dataDirectory, builderCleanDataDirectory, config, localeConfig, port, connectConfig, pgBinaryResolver, errRedirector, outRedirector, pgStartupWait);
+        }
+
+        // Package private accessors to allow PreparedDbProvider to check that the
+        // builder has no state set that would cause >1 invocations of start()
+        // to conflict with the previously started EmbeddedPostgres.
+        int getBuilderPort() {
+            return builderPort;
+        }
+
+        File getBuilderDataDirectory() {
+            return builderDataDirectory;
         }
     }
 

--- a/src/test/java/com/opentable/db/postgres/embedded/CustomPreparedDbProviderTest.java
+++ b/src/test/java/com/opentable/db/postgres/embedded/CustomPreparedDbProviderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.db.postgres.embedded;
+
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.Duration;
+
+import org.junit.Test;
+
+public class CustomPreparedDbProviderTest {
+    @Test
+    public void testTablesMade() throws Exception {
+        EmbeddedPostgres.Builder builder = EmbeddedPostgres.builder().setPGStartupWait(Duration.ofSeconds(20));
+        PreparedDbProvider dbProvider = PreparedDbProvider.forPreparerWithBuilder(FlywayPreparer.forClasspathLocation("db/testing"), builder);
+        try (Connection c = dbProvider.createDataSource().getConnection();
+                Statement s = c.createStatement()) {
+            ResultSet rs = s.executeQuery("SELECT * FROM foo");
+            rs.next();
+            assertEquals("bar", rs.getString(1));
+        }
+    }
+}


### PR DESCRIPTION
The PreparedDbProvider is awfully convenient, but because we're a bit heavy-handed with parallelism on our build hosts,  the postgres process sometimes fails to start within its 10 second deadline. If we could tune it, that would be neat, and this is one way we could do that.

The lazy option is to have a System property for the default timeout value, but doing it this may be more useful in general, as the EmbeddedPostgres.Builder supports other tweaks too.