### PR TITLE
add license to POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,15 @@
     <basepom.test.timeout>1800</basepom.test.timeout>
   </properties>
 
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+      <comments>A business-friendly OSS license</comments>
+    </license>
+  </licenses>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Currently, the License maven plugin (when run on projects which use this as a dependency) reports otj-pg-embedded as "unknown license" (and then people have to look manually what happens there).

Adding a `<licenses>` section to the pom.xml helps users to stay compliant.
Feel free to suggest a different location in the POM, I can update this PR.