### PR TITLE
Restored lost 'this' reference

### DIFF
--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -137,7 +137,7 @@ public class EmbeddedPostgres implements Closeable
             throw new IllegalArgumentException("no data directory");
         }
         LOG.trace("{} postgres data directory is {}", instanceId, this.dataDirectory);
-        mkdirs(dataDirectory);
+        mkdirs(this.dataDirectory);
 
         lockFile = new File(this.dataDirectory, LOCK_FILE_NAME);
 


### PR DESCRIPTION
In commit deecb481555b4df52be4284054637de2117c50f7 the 'this' reference of the dataDirectory field was lost.