### PR TITLE
Corrected locale parameter format and detected windows locale

### DIFF
--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -282,7 +282,12 @@ public class EmbeddedPostgres implements Closeable
     {
         final List<String> localeOptions = new ArrayList<>();
         for (final Entry<String, String> config : localeConfig.entrySet()) {
-          localeOptions.add(String.format("--%s=%s", config.getKey(), config.getValue()));
+            if (SystemUtils.IS_OS_WINDOWS) {
+                localeOptions.add(String.format("--%s=%s", config.getKey(), config.getValue()));
+            } else {
+                localeOptions.add("--" + config.getKey());
+                localeOptions.add(config.getValue());
+            }
         }
         return localeOptions;
     }

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -282,8 +282,7 @@ public class EmbeddedPostgres implements Closeable
     {
         final List<String> localeOptions = new ArrayList<>();
         for (final Entry<String, String> config : localeConfig.entrySet()) {
-          localeOptions.add("--" + config.getKey());
-          localeOptions.add(config.getValue());
+          localeOptions.add(String.format("--%s=%s", config.getKey(), config.getValue()));
         }
         return localeOptions;
     }

--- a/src/test/java/com/opentable/db/postgres/embedded/EmbeddedPostgresTest.java
+++ b/src/test/java/com/opentable/db/postgres/embedded/EmbeddedPostgresTest.java
@@ -16,6 +16,7 @@ package com.opentable.db.postgres.embedded;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -57,16 +58,27 @@ public class EmbeddedPostgresTest
 
     @Test
     public void testValidLocaleSettingsPassthrough() throws IOException {
-        final EmbeddedPostgres.Builder builder;
-        if (SystemUtils.IS_OS_WINDOWS) {
-            builder = EmbeddedPostgres.builder()
-                    .setLocaleConfig("locale", "en-us")
-                    .setLocaleConfig("lc-messages", "en-us");
-        } else {
-            builder = EmbeddedPostgres.builder()
-                    .setLocaleConfig("locale", "en_US")
-                    .setLocaleConfig("lc-messages", "en_US");
+        try {
+            EmbeddedPostgres.Builder builder = null;
+            if (SystemUtils.IS_OS_WINDOWS) {
+                builder = EmbeddedPostgres.builder()
+                        .setLocaleConfig("locale", "en-us")
+                        .setLocaleConfig("lc-messages", "en-us");
+            } else if (SystemUtils.IS_OS_MAC) {
+                builder = EmbeddedPostgres.builder()
+                        .setLocaleConfig("locale", "en_US")
+                        .setLocaleConfig("lc-messages", "en_US");
+            } else if (SystemUtils.IS_OS_LINUX){
+                builder = EmbeddedPostgres.builder()
+                        .setLocaleConfig("locale", "en_US.utf8")
+                        .setLocaleConfig("lc-messages", "en_US.utf8");
+            } else {
+                fail("System not detected!");
+            }
+            builder.start();
+        } catch (IllegalStateException e){
+            e.printStackTrace();
+            fail("Failed to set locale settings: " + e.getLocalizedMessage());
         }
-        builder.start();
     }
 }

--- a/src/test/java/com/opentable/db/postgres/embedded/EmbeddedPostgresTest.java
+++ b/src/test/java/com/opentable/db/postgres/embedded/EmbeddedPostgresTest.java
@@ -17,10 +17,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -51,5 +53,20 @@ public class EmbeddedPostgresTest
                 .start()) {
             // nothing to do
         }
+    }
+
+    @Test
+    public void testValidLocaleSettingsPassthrough() throws IOException {
+        final EmbeddedPostgres.Builder builder;
+        if (SystemUtils.IS_OS_WINDOWS) {
+            builder = EmbeddedPostgres.builder()
+                    .setLocaleConfig("locale", "en-us")
+                    .setLocaleConfig("lc-messages", "en-us");
+        } else {
+            builder = EmbeddedPostgres.builder()
+                    .setLocaleConfig("locale", "en_US")
+                    .setLocaleConfig("lc-messages", "en_US");
+        }
+        builder.start();
     }
 }


### PR DESCRIPTION
I added the described format for locale parameter like described here: https://www.postgresql.org/docs/9.5/static/app-initdb.html

I also found out that Windows don't know about `en_US` but its using `en-US` fine. For that I added a test for Windows and Non-Windows systems.

This should close #71