### PR TITLE
Attempt to allow using a local postgres directory

### DIFF
--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedUtil.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedUtil.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.db.postgres.embedded;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.SystemUtils;
+import org.tukaani.xz.XZInputStream;
+
+import java.io.*;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+
+class EmbeddedUtil {
+    static final String JDBC_FORMAT = "jdbc:postgresql://localhost:%s/%s?user=%s";
+    static final String PG_STOP_MODE = "fast";
+    static final String PG_STOP_WAIT_S = "5";
+    static final String PG_SUPERUSER = "postgres";
+    static final Duration DEFAULT_PG_STARTUP_WAIT = Duration.ofSeconds(10);
+    static final String LOCK_FILE_NAME = "epg-lock";
+
+
+    static File getWorkingDirectory() {
+        final File tempWorkingDirectory = new File(System.getProperty("java.io.tmpdir"), "embedded-pg");
+        return new File(System.getProperty("ot.epg.working-dir", tempWorkingDirectory.getPath()));
+    }
+
+
+    static void mkdirs(File dir) {
+        if (!dir.mkdirs() && !(dir.isDirectory() && dir.exists())) {
+            throw new IllegalStateException("could not create " + dir);
+        }
+    }
+
+    /**
+     * Get current operating system string. The string is used in the appropriate
+     * postgres binary name.
+     *
+     * @return Current operating system string.
+     */
+    static String getOS() {
+        if (SystemUtils.IS_OS_WINDOWS) {
+            return "Windows";
+        }
+        if (SystemUtils.IS_OS_MAC_OSX) {
+            return "Darwin";
+        }
+        if (SystemUtils.IS_OS_LINUX) {
+            return "Linux";
+        }
+        throw new UnsupportedOperationException("Unknown OS " + SystemUtils.OS_NAME);
+    }
+
+    /**
+     * Get the machine architecture string. The string is used in the appropriate
+     * postgres binary name.
+     *
+     * @return Current machine architecture string.
+     */
+    static String getArchitecture() {
+        return "amd64".equals(SystemUtils.OS_ARCH) ? "x86_64" : SystemUtils.OS_ARCH;
+    }
+
+    /**
+     * Unpack archive compressed by tar with xz compression. By default system tar is used (faster). If not found, then the
+     * java implementation takes place.
+     *
+     * @param tbzPath   The archive path.
+     * @param targetDir The directory to extract the content to.
+     */
+    static void extractTxz(String tbzPath, String targetDir) throws IOException {
+        try (
+                InputStream in = Files.newInputStream(Paths.get(tbzPath));
+                XZInputStream xzIn = new XZInputStream(in);
+                TarArchiveInputStream tarIn = new TarArchiveInputStream(xzIn)
+        ) {
+            TarArchiveEntry entry;
+
+            while ((entry = tarIn.getNextTarEntry()) != null) {
+                final String individualFile = entry.getName();
+                final File fsObject = new File(targetDir + "/" + individualFile);
+
+                if (entry.isSymbolicLink() || entry.isLink()) {
+                    Path target = FileSystems.getDefault().getPath(entry.getLinkName());
+                    Files.createSymbolicLink(fsObject.toPath(), target);
+                } else if (entry.isFile()) {
+                    byte[] content = new byte[(int) entry.getSize()];
+                    int read = tarIn.read(content, 0, content.length);
+                    if (read == -1) {
+                        throw new IllegalStateException("could not read " + individualFile);
+                    }
+                    mkdirs(fsObject.getParentFile());
+                    try (OutputStream outputFile = new FileOutputStream(fsObject)) {
+                        IOUtils.write(content, outputFile);
+                    }
+                } else if (entry.isDirectory()) {
+                    mkdirs(fsObject);
+                } else {
+                    throw new UnsupportedOperationException(
+                            String.format("Unsupported entry found: %s", individualFile)
+                    );
+                }
+
+                if (individualFile.startsWith("bin/") || individualFile.startsWith("./bin/")) {
+                    fsObject.setExecutable(true);
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedUtil.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedUtil.java
@@ -19,22 +19,21 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.tukaani.xz.XZInputStream;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.Duration;
 
-class EmbeddedUtil {
-    static final String JDBC_FORMAT = "jdbc:postgresql://localhost:%s/%s?user=%s";
-    static final String PG_STOP_MODE = "fast";
-    static final String PG_STOP_WAIT_S = "5";
-    static final String PG_SUPERUSER = "postgres";
-    static final Duration DEFAULT_PG_STARTUP_WAIT = Duration.ofSeconds(10);
+final class EmbeddedUtil {
+
     static final String LOCK_FILE_NAME = "epg-lock";
 
-
+    private EmbeddedUtil() {}
     static File getWorkingDirectory() {
         final File tempWorkingDirectory = new File(System.getProperty("java.io.tmpdir"), "embedded-pg");
         return new File(System.getProperty("ot.epg.working-dir", tempWorkingDirectory.getPath()));

--- a/src/main/java/com/opentable/db/postgres/embedded/PgDirectoryResolver.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/PgDirectoryResolver.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.db.postgres.embedded;
+
+import java.io.File;
+
+@FunctionalInterface
+public interface PgDirectoryResolver {
+    File getDirectory();
+}

--- a/src/main/java/com/opentable/db/postgres/embedded/UncompressBundleDirectoryResolver.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/UncompressBundleDirectoryResolver.java
@@ -13,6 +13,11 @@
  */
 package com.opentable.db.postgres.embedded;
 
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -25,12 +30,12 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static com.opentable.db.postgres.embedded.EmbeddedUtil.*;
-
-import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.io.IOUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static com.opentable.db.postgres.embedded.EmbeddedUtil.LOCK_FILE_NAME;
+import static com.opentable.db.postgres.embedded.EmbeddedUtil.extractTxz;
+import static com.opentable.db.postgres.embedded.EmbeddedUtil.getArchitecture;
+import static com.opentable.db.postgres.embedded.EmbeddedUtil.getOS;
+import static com.opentable.db.postgres.embedded.EmbeddedUtil.getWorkingDirectory;
+import static com.opentable.db.postgres.embedded.EmbeddedUtil.mkdirs;
 
 public class UncompressBundleDirectoryResolver implements PgDirectoryResolver {
 

--- a/src/main/java/com/opentable/db/postgres/embedded/UncompressBundleDirectoryResolver.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/UncompressBundleDirectoryResolver.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.db.postgres.embedded;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.FileLock;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static com.opentable.db.postgres.embedded.EmbeddedUtil.*;
+
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UncompressBundleDirectoryResolver implements PgDirectoryResolver {
+
+    private static volatile UncompressBundleDirectoryResolver DEFAULT_INSTANCE;
+
+    public static synchronized UncompressBundleDirectoryResolver getDefault() {
+        if (DEFAULT_INSTANCE == null) {
+            DEFAULT_INSTANCE = new UncompressBundleDirectoryResolver(new BundledPostgresBinaryResolver());
+        }
+        return DEFAULT_INSTANCE;
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(EmbeddedPostgres.class);
+    private final AtomicReference<File> binaryDir = new AtomicReference<>();
+    private final Lock prepareBinariesLock = new ReentrantLock();
+
+    private final PgBinaryResolver pgBinaryResolver;
+
+    public UncompressBundleDirectoryResolver(PgBinaryResolver pgBinaryResolver) {
+        this.pgBinaryResolver = pgBinaryResolver;
+    }
+
+    @Override
+    public File getDirectory() {
+        prepareBinariesLock.lock();
+        try {
+            if (binaryDir.get() != null) {
+                return binaryDir.get();
+            }
+
+            final String system = getOS();
+            final String machineHardware = getArchitecture();
+
+            LOG.info("Detected a {} {} system", system, machineHardware);
+            File pgDir;
+            File pgTbz;
+            final InputStream pgBinary;
+            try {
+                pgTbz = File.createTempFile("pgpg", "pgpg");
+                pgBinary = pgBinaryResolver.getPgBinary(system, machineHardware);
+            } catch (final IOException e) {
+                throw new ExceptionInInitializerError(e);
+            }
+
+            if (pgBinary == null) {
+                throw new IllegalStateException("No Postgres binary found for " + system + " / " + machineHardware);
+            }
+
+            try (DigestInputStream pgArchiveData = new DigestInputStream(pgBinary, MessageDigest.getInstance("MD5"));
+                 FileOutputStream os = new FileOutputStream(pgTbz)) {
+                IOUtils.copy(pgArchiveData, os);
+                pgArchiveData.close();
+                os.close();
+
+                String pgDigest = Hex.encodeHexString(pgArchiveData.getMessageDigest().digest());
+
+                pgDir = new File(getWorkingDirectory(), String.format("PG-%s", pgDigest));
+
+                mkdirs(pgDir);
+                final File unpackLockFile = new File(pgDir, LOCK_FILE_NAME);
+                final File pgDirExists = new File(pgDir, ".exists");
+
+                if (!pgDirExists.exists()) {
+                    try (FileOutputStream lockStream = new FileOutputStream(unpackLockFile);
+                         FileLock unpackLock = lockStream.getChannel().tryLock()) {
+                        if (unpackLock != null) {
+                            try {
+                                if (pgDirExists.exists()) {
+                                    throw new IllegalStateException(
+                                            "unpack lock acquired but .exists file is present " + pgDirExists);
+                                }
+                                LOG.info("Extracting Postgres...");
+                                extractTxz(pgTbz.getPath(), pgDir.getPath());
+                                if (!pgDirExists.createNewFile()) {
+                                    throw new IllegalStateException("couldn't make .exists file " + pgDirExists);
+                                }
+                            } catch (Exception e) {
+                                LOG.error("while unpacking Postgres", e);
+                            }
+                        } else {
+                            // the other guy is unpacking for us.
+                            int maxAttempts = 60;
+                            while (!pgDirExists.exists() && --maxAttempts > 0) {
+                                Thread.sleep(1000L);
+                            }
+                            if (!pgDirExists.exists()) {
+                                throw new IllegalStateException(
+                                        "Waited 60 seconds for postgres to be unpacked but it never finished!");
+                            }
+                        }
+                    } finally {
+                        if (unpackLockFile.exists() && !unpackLockFile.delete()) {
+                            LOG.error("could not remove lock file {}", unpackLockFile.getAbsolutePath());
+                        }
+                    }
+                }
+            } catch (final IOException | NoSuchAlgorithmException e) {
+                throw new ExceptionInInitializerError(e);
+            } catch (final InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new ExceptionInInitializerError(ie);
+            } finally {
+                if (!pgTbz.delete()) {
+                    LOG.warn("could not delete {}", pgTbz);
+                }
+            }
+            binaryDir.set(pgDir);
+            LOG.info("Postgres binaries at {}", pgDir);
+            return pgDir;
+        } finally {
+            prepareBinariesLock.unlock();
+        }
+    }
+
+
+}


### PR DESCRIPTION
This is a work in progress, just opening here as a reference. The idea would be to be able to use a local postgres directory for binaries, if provided, instead of a bundled one. 

This PR basically separates the handling of the embedded dir in a directory provider interface (`PgDirectoryResolver`), and moves all logic to handle existing bundles from the main class to a separate one (`UncompressBundleDirectoryResolver `) which implements the `PgDirectoryResolver` interface.