### PR TITLE
PreparedDbProvider: include username in connection string

### DIFF
--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -71,6 +71,7 @@ import org.tukaani.xz.XZInputStream;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressWarnings("PMD.AvoidDuplicateLiterals") // "postgres"
+@SuppressFBWarnings({"RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE", "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"}) // java 11 triggers: https://github.com/spotbugs/spotbugs/issues/756
 public class EmbeddedPostgres implements Closeable
 {
     private static final Logger LOG = LoggerFactory.getLogger(EmbeddedPostgres.class);

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -24,8 +24,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.net.SocketException;
-import java.net.UnknownHostException;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.FileSystems;
@@ -323,28 +321,12 @@ public class EmbeddedPostgres implements Closeable
     @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION")
     private void verifyReady(Map<String, String> connectConfig) throws SQLException
     {
-        final InetAddress localhost;
-        try {
-            localhost = InetAddress.getByAddress(new byte[]{127, 0, 0, 1});
-        } catch (final UnknownHostException e) {
-            throw new AssertionError("localhost unknown?", e);
-        }
-        final Socket sock = new Socket();
-        try {
+        final InetAddress localhost = InetAddress.getLoopbackAddress();
+        try (Socket sock = new Socket()) {
             sock.setSoTimeout((int) Duration.ofMillis(500).toMillis());
-        } catch (final SocketException e) {
-            throw new RuntimeException("error setting socket timeout", e);
-        }
-        try {
             sock.connect(new InetSocketAddress(localhost, port), (int) Duration.ofMillis(500).toMillis());
         } catch (final IOException e) {
             throw new SQLException("connect failed", e);
-        } finally {
-            try {
-                sock.close();
-            } catch (final IOException e) {
-                LOG.trace("i/o exception closing test socket", e);
-            }
         }
         try (Connection c = getPostgresDatabase(connectConfig).getConnection() ;
                 Statement s = c.createStatement() ;

--- a/src/main/java/com/opentable/db/postgres/embedded/PreparedDbProvider.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/PreparedDbProvider.java
@@ -221,7 +221,7 @@ public class PreparedDbProvider
         }
     }
 
-    @SuppressFBWarnings("OBL_UNSATISFIED_OBLIGATION")
+    @SuppressFBWarnings({"OBL_UNSATISFIED_OBLIGATION", "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"})
     private static void create(final DataSource connectDb, final String dbName, final String userName) throws SQLException
     {
         if (dbName == null) {

--- a/src/main/java/com/opentable/db/postgres/embedded/PreparedDbProvider.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/PreparedDbProvider.java
@@ -37,7 +37,7 @@ import com.opentable.db.postgres.embedded.EmbeddedPostgres.Builder;
 
 public class PreparedDbProvider
 {
-    private static final String JDBC_FORMAT = "jdbc:postgresql://localhost:%d/%s";
+    private static final String JDBC_FORMAT = "jdbc:postgresql://localhost:%d/%s?user=%s";
 
     /**
      * Each database cluster's <code>template1</code> database has a unique set of schema
@@ -140,7 +140,7 @@ public class PreparedDbProvider
 
     String getJdbcUri(DbInfo db)
     {
-        return String.format(JDBC_FORMAT, db.port, db.dbName);
+        return String.format(JDBC_FORMAT, db.port, db.dbName, db.user);
     }
 
     /**

--- a/src/test/java/com/opentable/db/postgres/embedded/PreparedDbTest.java
+++ b/src/test/java/com/opentable/db/postgres/embedded/PreparedDbTest.java
@@ -16,6 +16,7 @@ package com.opentable.db.postgres.embedded;
 import static org.junit.Assert.assertEquals;
 
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -71,6 +72,15 @@ public class PreparedDbTest {
         ConnectionInfo dbInfo = dbA1.getConnectionInfo();
         DataSource dataSource = dbA1.getTestDatabase();
         try (Connection c = dataSource.getConnection(); Statement stmt = c.createStatement()) {
+            commonAssertion(stmt);
+            assertEquals(dbInfo.getUser(), c.getMetaData().getUserName());
+        }
+    }
+
+    @Test
+    public void testDbUri() throws Exception {
+        try (Connection c = DriverManager.getConnection(dbA1.getDbProvider().createDatabase());
+             Statement stmt = c.createStatement()) {
             commonAssertion(stmt);
         }
     }


### PR DESCRIPTION
Currently it forgets to do so, which makes the method nearly useless, as it by default uses the current username.  Unless your name happens to be "Postgres", in which case you probably want to shop for some new parents.

Includes a couple of bonus cleanups that improved building on Java 11 and outside of OT.