### PR TITLE
Clean up thread name of output logger

### DIFF
--- a/src/main/java/com/opentable/db/postgres/embedded/ProcessOutputLogger.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/ProcessOutputLogger.java
@@ -63,7 +63,7 @@ final class ProcessOutputLogger implements Runnable {
 
     static void logOutput(final Logger logger, final Process process) {
         final Thread t = new Thread(new ProcessOutputLogger(logger, process));
-        t.setName("output redirector for " + process);
+        t.setName("pg-" + process.pid());
         t.start();
     }
 }


### PR DESCRIPTION
Since this is only computed at start and never update, including things like 'exitValue' is misleading.
Plus the log lines are really long when you have an 80 character thread name.