### PR TITLE
Clean up logger names take 2

### DIFF
--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -64,6 +64,7 @@ import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.commons.lang3.SystemUtils;
@@ -264,7 +265,7 @@ public class EmbeddedPostgres implements Closeable
         final Process postmaster = builder.start();
 
         if (outputRedirector.type() == ProcessBuilder.Redirect.Type.PIPE) {
-            ProcessOutputLogger.logOutput(LOG, postmaster);
+            ProcessOutputLogger.logOutput(LoggerFactory.getLogger("pg-" + instanceId), postmaster);
         }
 
         LOG.info("{} postmaster started as {} on port {}.  Waiting up to {} for server startup to finish.", instanceId, postmaster.toString(), port, pgStartupWait);
@@ -619,7 +620,7 @@ public class EmbeddedPostgres implements Closeable
             final Process process = builder.start();
 
             if (outputRedirector.type() == ProcessBuilder.Redirect.Type.PIPE) {
-                ProcessOutputLogger.logOutput(LOG, process);
+                ProcessOutputLogger.logOutput(LoggerFactory.getLogger("init-" + instanceId + ":" + FilenameUtils.getName(command[0])), process);
             }
             if (0 != process.waitFor()) {
                 throw new IllegalStateException(String.format("Process %s failed%n%s", Arrays.asList(command), IOUtils.toString(process.getErrorStream())));

--- a/src/main/java/com/opentable/db/postgres/embedded/ProcessOutputLogger.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/ProcessOutputLogger.java
@@ -20,6 +20,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
@@ -50,7 +51,7 @@ final class ProcessOutputLogger implements Runnable {
         try {
             while (process.isAlive()) {
                 try {
-                    logger.info(reader.readLine());
+                    Optional.ofNullable(reader.readLine()).ifPresent(logger::info);
                 } catch (final IOException e) {
                     logger.error("while reading output", e);
                     return;

--- a/src/main/java/com/opentable/db/postgres/embedded/ProcessOutputLogger.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/ProcessOutputLogger.java
@@ -16,8 +16,12 @@ package com.opentable.db.postgres.embedded;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 
 /**
@@ -63,7 +67,20 @@ final class ProcessOutputLogger implements Runnable {
 
     static void logOutput(final Logger logger, final Process process) {
         final Thread t = new Thread(new ProcessOutputLogger(logger, process));
-        t.setName("output redirector for " + process);
+        t.setName("log:" + describe(process));
         t.start();
+    }
+
+    @SuppressFBWarnings("REC_CATCH_EXCEPTION") // expected and ignored
+    private static String describe(Process process) {
+        try { // java 9+
+            return String.format("pid(%s)", MethodHandles.lookup().findVirtual(Process.class, "pid", MethodType.methodType(long.class)).invoke(process));
+        } catch (Throwable ignored) {} // NOPMD since MethodHandles.invoke throws Throwable
+        try { // openjdk / oraclejdk 8
+            final Field pid = process.getClass().getDeclaredField("pid");
+            pid.setAccessible(true);
+            return String.format("pid(%s)", pid.getInt(process));
+        } catch (Exception ignored) {}
+        return process.toString(); // anything goes wrong
     }
 }


### PR DESCRIPTION
looks like:
```
[log:pid(10954)] INFO init-a8f7dbf9-dd2f-4309-a75b-a3c64bca52cc:initdb - The database cluster will be initialized with locale "en_US.utf8".
[log:pid(10937)] INFO pg-81b23943-57f6-4220-a53e-0c8f52a3c239 - 2019-01-17 10:38:11.463 PST [10940] LOG:  listening on IPv4 address "127.0.0.1", port 32953
```

replaces #95
