### PR TITLE
Expose contexts for LiquibasePreparer

### DIFF
--- a/src/main/java/com/opentable/db/postgres/embedded/LiquibasePreparer.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/LiquibasePreparer.java
@@ -30,13 +30,18 @@ import static liquibase.database.DatabaseFactory.getInstance;
 public final class LiquibasePreparer implements DatabasePreparer {
 
     private final String location;
+    private final Contexts contexts;
 
     public static LiquibasePreparer forClasspathLocation(String location) {
-        return new LiquibasePreparer(location);
+        return new LiquibasePreparer(location, new Contexts());
+    }
+    public static LiquibasePreparer forClasspathLocation(String location, Contexts contexts) {
+        return new LiquibasePreparer(location, contexts);
     }
 
-    private LiquibasePreparer(String location) {
+    private LiquibasePreparer(String location, Contexts contexts) {
         this.location = location;
+        this.contexts = contexts;
     }
 
     @Override
@@ -46,7 +51,7 @@ public final class LiquibasePreparer implements DatabasePreparer {
             connection = ds.getConnection();
             Database database = getInstance().findCorrectDatabaseImplementation(new JdbcConnection(connection));
             Liquibase liquibase = new Liquibase(location, new ClassLoaderResourceAccessor(), database);
-            liquibase.update(new Contexts());
+            liquibase.update(contexts);
         } catch (LiquibaseException e) {
             throw new SQLException(e);
         } finally {

--- a/src/test/java/com/opentable/db/postgres/embedded/LiquibasePreparerContextTest.java
+++ b/src/test/java/com/opentable/db/postgres/embedded/LiquibasePreparerContextTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.db.postgres.embedded;
+
+import com.opentable.db.postgres.junit.EmbeddedPostgresRules;
+import com.opentable.db.postgres.junit.PreparedDbRule;
+import liquibase.Contexts;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
+
+public class LiquibasePreparerContextTest {
+    @Rule
+    public PreparedDbRule db = EmbeddedPostgresRules.preparedDatabase(LiquibasePreparer.forClasspathLocation("liqui/master-test.xml", new Contexts("test")));
+
+    @Test
+    public void testEmptyTables() throws Exception {
+        try (Connection c = db.getTestDatabase().getConnection();
+             Statement s = c.createStatement()) {
+            ResultSet rs = s.executeQuery("SELECT COUNT(*) FROM foo");
+            rs.next();
+            assertEquals(0, rs.getInt(1));
+        }
+    }
+}

--- a/src/test/resources/liqui/master-test.xml
+++ b/src/test/resources/liqui/master-test.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <include file="liqui/master.xml"/>
+
+    <changeSet id="deleteAll" author="foo.bar" context="test">
+        <comment>Delete from `foo` table</comment>
+        <delete tableName="foo"/>
+    </changeSet>
+
+    <changeSet id="reInsertBar" author="foo.bar" context="local">
+        <comment>Fill `foo` table</comment>
+        <sql>INSERT INTO foo VALUES('bar');</sql>
+    </changeSet>
+
+</databaseChangeLog>
+
+


### PR DESCRIPTION
This variable should be exposed such that it is possible to run changesets for specific configurations in tests.