### PR TITLE
Add OpenJDK 11 to the Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: java
 jdk:
-  - oraclejdk8
-
+  - openjdk8
+  - openjdk11
+cache:
+  directories:
+    - dist
+    - $HOME/.m2


### PR DESCRIPTION
This adds JDK 11 as a test target, and updates oraclejdk8 to openjdk8, as Oracle's JDK 8 is no longer installable on Travis CI.