### PR TITLE
Check if directory that should hold PG binaries exists

### DIFF
--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -688,7 +688,7 @@ public class EmbeddedPostgres implements Closeable
 
             while ((entry = tarIn.getNextTarEntry()) != null) { //NOPMD
                 final String individualFile = entry.getName();
-                final File fsObject = new File(targetDir + "/" + individualFile);
+                final File fsObject = new File(targetDir, individualFile);
 
                 if (entry.isSymbolicLink() || entry.isLink()) {
                     Path target = FileSystems.getDefault().getPath(entry.getLinkName());
@@ -748,7 +748,7 @@ public class EmbeddedPostgres implements Closeable
     {
         PREPARE_BINARIES_LOCK.lock();
         try {
-            if (PREPARE_BINARIES.containsKey(pgBinaryResolver)) {
+            if (PREPARE_BINARIES.containsKey(pgBinaryResolver) && PREPARE_BINARIES.get(pgBinaryResolver).exists()) {
                 return PREPARE_BINARIES.get(pgBinaryResolver);
             }
 


### PR DESCRIPTION
I've found that after a few days of usage of this library that some of the binaries like `initdb` are deleted. I don't really understand why, but suspect it may be due to the temp cleaner on macOS.

Often, the only way to fix this is to delete the entire `embedded-pg` directory.

I am running my tests from a Clojure REPL. After I've deleted `embedded-pg` directory, the `PREPARE_BINARIES` static variable still refers to the non-existent folder. This means I have to restart my REPL after deleting the directory which is slow and can be confusing to debug for newcomers who don't understand that `PREPARE_BINARIES` will exist for the life of the process.

This PR adds a check that the directory still exists before returning from `prepareBinaries`. 

Relates to #108