### PR TITLE
Fix for unrecoverable state when test is interrupted during extraction

### DIFF
--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -74,7 +74,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tukaani.xz.XZInputStream;
 
-import static java.nio.file.StandardOpenOption.CREATE_NEW;
+import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.WRITE;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -706,7 +706,7 @@ public class EmbeddedPostgres implements Closeable
                     }
                     mkdirs(fsObject.getParentFile());
 
-                    final AsynchronousFileChannel fileChannel = AsynchronousFileChannel.open(fsObject.toPath(), CREATE_NEW, WRITE);
+                    final AsynchronousFileChannel fileChannel = AsynchronousFileChannel.open(fsObject.toPath(), CREATE, WRITE);
                     final ByteBuffer buffer = ByteBuffer.wrap(content);
 
                     phaser.register();


### PR DESCRIPTION
If the test got interrupted while an archive was being extracted, it results in an unrecoverable state since the extraction doesn't have the marker `.exists` file yet, but the archive is half-way extracted. The extraction keeps on failing on subsequent runs because `CREATE_NEW` flag is being used which results in an exception if the file already exists.

This PR modifies that flag to `CREATE` so the existing files can be overwritten.