### PR TITLE
Allow using an existing postgres instead of unpacking one from the JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
     <basepom.oss.skip-scala-doc>true</basepom.oss.skip-scala-doc>
     <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
     <basepom.check.fail-javadoc>false</basepom.check.fail-javadoc>
-    <dep.plugin.expose-versions-maven-plugin.version>1.6</dep.plugin.expose-versions-maven-plugin.version>
   </properties>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <basepom.oss.skip-scala-doc>true</basepom.oss.skip-scala-doc>
     <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
     <basepom.check.fail-javadoc>false</basepom.check.fail-javadoc>
+    <dep.plugin.expose-versions-maven-plugin.version>1.6</dep.plugin.expose-versions-maven-plugin.version>
   </properties>
 
   <licenses>

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -14,28 +14,22 @@
 package com.opentable.db.postgres.embedded;
 
 
-import java.io.ByteArrayInputStream;
+import static com.opentable.db.postgres.embedded.EmbeddedUtil.getWorkingDirectory;
+import static com.opentable.db.postgres.embedded.EmbeddedUtil.mkdirs;
+
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.nio.ByteBuffer;
-import java.nio.channels.AsynchronousFileChannel;
-import java.nio.channels.Channel;
-import java.nio.channels.CompletionHandler;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
-import java.nio.file.FileSystems;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.DigestInputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -51,31 +45,21 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 import javax.sql.DataSource;
 
-import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.time.StopWatch;
 import org.postgresql.ds.PGSimpleDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.tukaani.xz.XZInputStream;
 
-import static java.nio.file.StandardOpenOption.CREATE;
-import static java.nio.file.StandardOpenOption.WRITE;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressWarnings("PMD.AvoidDuplicateLiterals") // "postgres"
@@ -114,27 +98,29 @@ public class EmbeddedPostgres implements Closeable
 
     EmbeddedPostgres(File parentDirectory, File dataDirectory, boolean cleanDataDirectory,
         Map<String, String> postgresConfig, Map<String, String> localeConfig, int port, Map<String, String> connectConfig,
-        PgBinaryResolver pgBinaryResolver, ProcessBuilder.Redirect errorRedirector, ProcessBuilder.Redirect outputRedirector) throws IOException
+        PgDirectoryResolver pgDirectoryResolver, ProcessBuilder.Redirect errorRedirector, ProcessBuilder.Redirect outputRedirector) throws IOException
     {
         this(parentDirectory, dataDirectory, cleanDataDirectory, postgresConfig, localeConfig, port, connectConfig,
-                pgBinaryResolver, errorRedirector, outputRedirector, DEFAULT_PG_STARTUP_WAIT, Optional.empty());
+                pgDirectoryResolver, errorRedirector, outputRedirector, DEFAULT_PG_STARTUP_WAIT, Optional.empty());
     }
 
     EmbeddedPostgres(File parentDirectory, File dataDirectory, boolean cleanDataDirectory,
                      Map<String, String> postgresConfig, Map<String, String> localeConfig, int port, Map<String, String> connectConfig,
-                     PgBinaryResolver pgBinaryResolver, ProcessBuilder.Redirect errorRedirector,
+                     PgDirectoryResolver pgDirectoryResolver, ProcessBuilder.Redirect errorRedirector,
                      ProcessBuilder.Redirect outputRedirector, Duration pgStartupWait,
                      Optional<File> overrideWorkingDirectory) throws IOException
     {
+
         this.cleanDataDirectory = cleanDataDirectory;
         this.postgresConfig = new HashMap<>(postgresConfig);
         this.localeConfig = new HashMap<>(localeConfig);
         this.port = port;
-        this.pgDir = prepareBinaries(pgBinaryResolver, overrideWorkingDirectory);
+        this.pgDir = pgDirectoryResolver.getDirectory(overrideWorkingDirectory);
         this.errorRedirector = errorRedirector;
         this.outputRedirector = outputRedirector;
-        this.pgStartupWait = pgStartupWait;
-        Objects.requireNonNull(this.pgStartupWait, "Wait time cannot be null");
+        this.pgStartupWait = Objects.requireNonNull(pgStartupWait, "Wait time cannot be null");
+        ;
+
 
         if (parentDirectory != null) {
             mkdirs(parentDirectory);
@@ -150,7 +136,7 @@ public class EmbeddedPostgres implements Closeable
         if (this.dataDirectory == null) {
             throw new IllegalArgumentException("no data directory");
         }
-        LOG.trace("{} postgres data directory is {}", instanceId, this.dataDirectory);
+        LOG.info("{} postgres: data directory is {}, postgres directory is {}", instanceId, this.dataDirectory, this.pgDir);
         mkdirs(this.dataDirectory);
 
         lockFile = new File(this.dataDirectory, LOCK_FILE_NAME);
@@ -163,13 +149,11 @@ public class EmbeddedPostgres implements Closeable
         startPostmaster(connectConfig);
     }
 
-    public DataSource getTemplateDatabase()
-    {
+    public DataSource getTemplateDatabase() {
         return getDatabase("postgres", "template1");
     }
 
-    public DataSource getTemplateDatabase(Map<String, String> properties)
-    {
+    public DataSource getTemplateDatabase(Map<String, String> properties) {
         return getDatabase("postgres", "template1", properties);
     }
 
@@ -177,8 +161,7 @@ public class EmbeddedPostgres implements Closeable
         return getDatabase("postgres", "postgres");
     }
 
-    public DataSource getPostgresDatabase(Map<String, String> properties)
-    {
+    public DataSource getPostgresDatabase(Map<String, String> properties) {
         return getDatabase("postgres", "postgres", properties);
     }
 
@@ -186,8 +169,7 @@ public class EmbeddedPostgres implements Closeable
         return getDatabase(userName, dbName, Collections.emptyMap());
     }
 
-    public DataSource getDatabase(String userName, String dbName, Map<String, String> properties)
-    {
+    public DataSource getDatabase(String userName, String dbName, Map<String, String> properties) {
         final PGSimpleDataSource ds = new PGSimpleDataSource();
         ds.setServerName("localhost");
         ds.setPortNumber(port);
@@ -204,18 +186,15 @@ public class EmbeddedPostgres implements Closeable
         return ds;
     }
 
-    public String getJdbcUrl(String userName, String dbName)
-    {
+    public String getJdbcUrl(String userName, String dbName) {
         return String.format(JDBC_FORMAT, port, dbName, userName);
     }
 
-    public int getPort()
-    {
+    public int getPort() {
         return port;
     }
 
-    private static int detectPort() throws IOException
-    {
+    private static int detectPort() throws IOException {
         try (ServerSocket socket = new ServerSocket(0)) {
             while(!socket.isBound()) {
                 Thread.sleep(50);
@@ -227,16 +206,14 @@ public class EmbeddedPostgres implements Closeable
         }
     }
 
-    private void lock() throws IOException
-    {
+    private void lock() throws IOException {
         lockStream = new FileOutputStream(lockFile);
         if ((lock = lockStream.getChannel().tryLock()) == null) { //NOPMD
             throw new IllegalStateException("could not lock " + lockFile);
         }
     }
 
-    private void initdb()
-    {
+    private void initdb() {
         final StopWatch watch = new StopWatch();
         watch.start();
         List<String> command = new ArrayList<>();
@@ -248,8 +225,7 @@ public class EmbeddedPostgres implements Closeable
         LOG.info("{} initdb completed in {}", instanceId, watch);
     }
 
-    private void startPostmaster(Map<String, String> connectConfig) throws IOException
-    {
+    private void startPostmaster(Map<String, String> connectConfig) throws IOException {
         final StopWatch watch = new StopWatch();
         watch.start();
         if (started.getAndSet(true)) {
@@ -284,15 +260,13 @@ public class EmbeddedPostgres implements Closeable
         waitForServerStartup(watch, connectConfig);
     }
 
-    private List<String> createInitOptions()
-    {
+    private List<String> createInitOptions() {
         final List<String> initOptions = new ArrayList<>();
         initOptions.addAll(Arrays.asList(
                 "-p", Integer.toString(port),
                 "-F"));
 
-        for (final Entry<String, String> config : postgresConfig.entrySet())
-        {
+        for (final Entry<String, String> config : postgresConfig.entrySet()) {
             initOptions.add("-c");
             initOptions.add(config.getKey() + "=" + config.getValue());
         }
@@ -300,8 +274,7 @@ public class EmbeddedPostgres implements Closeable
         return initOptions;
     }
 
-    private List<String> createLocaleOptions()
-    {
+    private List<String> createLocaleOptions() {
         final List<String> localeOptions = new ArrayList<>();
         for (final Entry<String, String> config : localeConfig.entrySet()) {
             if (SystemUtils.IS_OS_WINDOWS) {
@@ -314,8 +287,7 @@ public class EmbeddedPostgres implements Closeable
         return localeOptions;
     }
 
-    private void waitForServerStartup(StopWatch watch, Map<String, String> connectConfig) throws IOException
-    {
+    private void waitForServerStartup(StopWatch watch, Map<String, String> connectConfig) throws IOException {
         Throwable lastCause = null;
         final long start = System.nanoTime();
         final long maxWaitNs = TimeUnit.NANOSECONDS.convert(pgStartupWait.toMillis(), TimeUnit.MILLISECONDS);
@@ -344,15 +316,15 @@ public class EmbeddedPostgres implements Closeable
     {
         final InetAddress localhost = InetAddress.getLoopbackAddress();
         try (Socket sock = new Socket()) {
+
             sock.setSoTimeout((int) Duration.ofMillis(500).toMillis());
             sock.connect(new InetSocketAddress(localhost, port), (int) Duration.ofMillis(500).toMillis());
         } catch (final IOException e) {
             throw new SQLException("connect failed", e);
         }
-        try (Connection c = getPostgresDatabase(connectConfig).getConnection() ;
-                Statement s = c.createStatement() ;
-                ResultSet rs = s.executeQuery("SELECT 1"))
-        {
+        try (Connection c = getPostgresDatabase(connectConfig).getConnection();
+             Statement s = c.createStatement();
+             ResultSet rs = s.executeQuery("SELECT 1")) {
             if (!rs.next()) {
                 throw new IllegalStateException("expecting single row");
             }
@@ -365,16 +337,13 @@ public class EmbeddedPostgres implements Closeable
         }
     }
 
-    private Thread newCloserThread()
-    {
+    private Thread newCloserThread() {
         final Thread closeThread = new Thread(new Runnable() {
             @Override
-            public void run()
-            {
+            public void run() {
                 try {
                     EmbeddedPostgres.this.close();
-                }
-                catch (IOException ex) {
+                } catch (IOException ex) {
                     LOG.error("Unexpected IOException from Closeables.close", ex);
                 }
             }
@@ -384,8 +353,7 @@ public class EmbeddedPostgres implements Closeable
     }
 
     @Override
-    public void close() throws IOException
-    {
+    public void close() throws IOException {
         if (closed.getAndSet(true)) {
             return;
         }
@@ -417,19 +385,16 @@ public class EmbeddedPostgres implements Closeable
         }
     }
 
-    private void pgCtl(File dir, String action)
-    {
+    private void pgCtl(File dir, String action) {
         system(pgBin("pg_ctl"), "-D", dir.getPath(), action, "-m", PG_STOP_MODE, "-t", PG_STOP_WAIT_S, "-w");
     }
 
-    private void cleanOldDataDirectories(File parentDirectory)
-    {
+    private void cleanOldDataDirectories(File parentDirectory) {
         final File[] children = parentDirectory.listFiles();
         if (children == null) {
             return;
         }
-        for (final File dir : children)
-        {
+        for (final File dir : children) {
             if (!dir.isDirectory()) {
                 continue;
             }
@@ -466,30 +431,21 @@ public class EmbeddedPostgres implements Closeable
         }
     }
 
-    private String pgBin(String binaryName)
-    {
+    private String pgBin(String binaryName) {
         final String extension = SystemUtils.IS_OS_WINDOWS ? ".exe" : "";
         return new File(pgDir, "bin/" + binaryName + extension).getPath();
     }
 
-    private static File getWorkingDirectory()
-    {
-        final File tempWorkingDirectory = new File(System.getProperty("java.io.tmpdir"), "embedded-pg");
-        return new File(System.getProperty("ot.epg.working-dir", tempWorkingDirectory.getPath()));
-    }
 
-    public static EmbeddedPostgres start() throws IOException
-    {
+    public static EmbeddedPostgres start() throws IOException {
         return builder().start();
     }
 
-    public static EmbeddedPostgres.Builder builder()
-    {
+    public static EmbeddedPostgres.Builder builder() {
         return new Builder();
     }
 
-    public static class Builder
-    {
+    public static class Builder {
         private final File parentDirectory = getWorkingDirectory();
         private Optional<File> overrideWorkingDirectory = Optional.empty(); // use tmpdir
         private File builderDataDirectory;
@@ -498,7 +454,7 @@ public class EmbeddedPostgres implements Closeable
         private boolean builderCleanDataDirectory = true;
         private int builderPort = 0;
         private final Map<String, String> connectConfig = new HashMap<>();
-        private PgBinaryResolver pgBinaryResolver = new BundledPostgresBinaryResolver();
+        private PgDirectoryResolver pgDirectoryResolver;
         private Duration pgStartupWait = DEFAULT_PG_STARTUP_WAIT;
 
         private ProcessBuilder.Redirect errRedirector = ProcessBuilder.Redirect.PIPE;
@@ -513,12 +469,13 @@ public class EmbeddedPostgres implements Closeable
         public Builder setPGStartupWait(Duration pgStartupWait) {
             Objects.requireNonNull(pgStartupWait);
             if (pgStartupWait.isNegative()) {
-               throw new IllegalArgumentException("Negative durations are not permitted.");
+                throw new IllegalArgumentException("Negative durations are not permitted.");
             }
 
             this.pgStartupWait = pgStartupWait;
             return this;
         }
+
         public Builder setCleanDataDirectory(boolean cleanDataDirectory) {
             builderCleanDataDirectory = cleanDataDirectory;
             return this;
@@ -567,27 +524,37 @@ public class EmbeddedPostgres implements Closeable
             return this;
         }
 
-        public Builder setOutputRedirector(ProcessBuilder.Redirect outRedirector)
-        {
+        public Builder setOutputRedirector(ProcessBuilder.Redirect outRedirector) {
             this.outRedirector = outRedirector;
             return this;
         }
 
+        @Deprecated
         public Builder setPgBinaryResolver(PgBinaryResolver pgBinaryResolver) {
-            this.pgBinaryResolver = pgBinaryResolver;
+            return setPgDirectoryResolver(new UncompressBundleDirectoryResolver(pgBinaryResolver));
+        }
+
+        public Builder setPgDirectoryResolver(PgDirectoryResolver pgDirectoryResolver) {
+            this.pgDirectoryResolver = pgDirectoryResolver;
             return this;
         }
 
+        public Builder setPostgresBinaryDirectory(File directory) {
+            return setPgDirectoryResolver((x) -> directory);
+        }
+
         public EmbeddedPostgres start() throws IOException {
-            if (builderPort == 0)
-            {
+            if (builderPort == 0) {
                 builderPort = detectPort();
             }
             if (builderDataDirectory == null) {
                 builderDataDirectory = Files.createTempDirectory("epg").toFile();
             }
+            if (pgDirectoryResolver == null) {
+                pgDirectoryResolver = UncompressBundleDirectoryResolver.getDefault();
+            }
             return new EmbeddedPostgres(parentDirectory, builderDataDirectory, builderCleanDataDirectory, config,
-                    localeConfig, builderPort, connectConfig, pgBinaryResolver, errRedirector, outRedirector,
+                    localeConfig, builderPort, connectConfig, pgDirectoryResolver, errRedirector, outRedirector,
                     pgStartupWait, overrideWorkingDirectory);
         }
 
@@ -607,7 +574,7 @@ public class EmbeddedPostgres implements Closeable
                     Objects.equals(config, builder.config) &&
                     Objects.equals(localeConfig, builder.localeConfig) &&
                     Objects.equals(connectConfig, builder.connectConfig) &&
-                    Objects.equals(pgBinaryResolver, builder.pgBinaryResolver) &&
+                    Objects.equals(pgDirectoryResolver, builder.pgDirectoryResolver) &&
                     Objects.equals(pgStartupWait, builder.pgStartupWait) &&
                     Objects.equals(errRedirector, builder.errRedirector) &&
                     Objects.equals(outRedirector, builder.outRedirector);
@@ -615,7 +582,7 @@ public class EmbeddedPostgres implements Closeable
 
         @Override
         public int hashCode() {
-            return Objects.hash(parentDirectory, builderDataDirectory, config, localeConfig, builderCleanDataDirectory, builderPort, connectConfig, pgBinaryResolver, pgStartupWait, errRedirector, outRedirector);
+            return Objects.hash(parentDirectory, builderDataDirectory, config, localeConfig, builderCleanDataDirectory, builderPort, connectConfig, pgDirectoryResolver, pgStartupWait, errRedirector, outRedirector);
         }
     }
 
@@ -634,7 +601,7 @@ public class EmbeddedPostgres implements Closeable
                 ProcessOutputLogger.logOutput(LoggerFactory.getLogger(LOG_PREFIX + "init-" + instanceId + ":" + FilenameUtils.getName(command[0])), process);
             }
             if (0 != process.waitFor()) {
-                throw new IllegalStateException(String.format("Process %s failed%n%s", Arrays.asList(command), IOUtils.toString(process.getErrorStream())));
+                throw new IllegalStateException(String.format("Process %s failed%n%s", Arrays.asList(command), IOUtils.toString(process.getErrorStream(), StandardCharsets.UTF_8)));
             }
         } catch (final RuntimeException e) { // NOPMD
             throw e;
@@ -643,206 +610,9 @@ public class EmbeddedPostgres implements Closeable
         }
     }
 
-    private static void mkdirs(File dir)
-    {
-        if (!dir.mkdirs() && !(dir.isDirectory() && dir.exists())) {
-            throw new IllegalStateException("could not create " + dir);
-        }
-    }
-
-    private static final Lock PREPARE_BINARIES_LOCK = new ReentrantLock();
-    private static final Map<PgBinaryResolver, File> PREPARE_BINARIES = new HashMap<>();
-
-    /**
-     * Get current operating system string. The string is used in the appropriate postgres binary name.
-     *
-     * @return Current operating system string.
-     */
-    private static String getOS()
-    {
-        if (SystemUtils.IS_OS_WINDOWS) {
-            return "Windows";
-        }
-        if (SystemUtils.IS_OS_MAC_OSX) {
-            return "Darwin";
-        }
-        if (SystemUtils.IS_OS_LINUX) {
-            return "Linux";
-        }
-        throw new UnsupportedOperationException("Unknown OS " + SystemUtils.OS_NAME);
-    }
-
-    /**
-     * Get the machine architecture string. The string is used in the appropriate postgres binary name.
-     *
-     * @return Current machine architecture string.
-     */
-    private static String getArchitecture()
-    {
-        return "amd64".equals(SystemUtils.OS_ARCH) ? "x86_64" : SystemUtils.OS_ARCH;
-    }
-
-    /**
-     * Unpack archive compressed by tar with xz compression. By default system tar is used (faster). If not found, then the
-     * java implementation takes place.
-     *
-     * @param stream    A stream with the postgres binaries.
-     * @param targetDir The directory to extract the content to.
-     */
-    private static void extractTxz(InputStream stream, String targetDir) throws IOException {
-        try (
-                XZInputStream xzIn = new XZInputStream(stream);
-                TarArchiveInputStream tarIn = new TarArchiveInputStream(xzIn)
-        ) {
-            final Phaser phaser = new Phaser(1);
-            TarArchiveEntry entry;
-
-            while ((entry = tarIn.getNextTarEntry()) != null) { //NOPMD
-                final String individualFile = entry.getName();
-                final File fsObject = new File(targetDir, individualFile);
-
-                if (entry.isSymbolicLink() || entry.isLink()) {
-                    Path target = FileSystems.getDefault().getPath(entry.getLinkName());
-                    Files.createSymbolicLink(fsObject.toPath(), target);
-                } else if (entry.isFile()) {
-                    byte[] content = new byte[(int) entry.getSize()];
-                    int read = tarIn.read(content, 0, content.length);
-                    if (read == -1) {
-                        throw new IllegalStateException("could not read " + individualFile);
-                    }
-                    mkdirs(fsObject.getParentFile());
-
-                    final AsynchronousFileChannel fileChannel = AsynchronousFileChannel.open(fsObject.toPath(), CREATE, WRITE); //NOPMD
-                    final ByteBuffer buffer = ByteBuffer.wrap(content); //NOPMD
-
-                    phaser.register();
-                    fileChannel.write(buffer, 0, fileChannel, new CompletionHandler<Integer, Channel>() {
-                        @Override
-                        public void completed(Integer written, Channel channel) {
-                            closeChannel(channel);
-                        }
-
-                        @Override
-                        public void failed(Throwable error, Channel channel) {
-                            LOG.error("Could not write file {}", fsObject.getAbsolutePath(), error);
-                            closeChannel(channel);
-                        }
-
-                        private void closeChannel(Channel channel) {
-                            try {
-                                channel.close();
-                            } catch (IOException e) {
-                                LOG.error("Unexpected error while closing the channel", e);
-                            } finally {
-                                phaser.arriveAndDeregister();
-                            }
-                        }
-                    });
-                } else if (entry.isDirectory()) {
-                    mkdirs(fsObject);
-                } else {
-                    throw new UnsupportedOperationException(
-                            String.format("Unsupported entry found: %s", individualFile)
-                    );
-                }
-
-                if (individualFile.startsWith("bin/") || individualFile.startsWith("./bin/")) {
-                    fsObject.setExecutable(true);
-                }
-            }
-
-            phaser.arriveAndAwaitAdvance();
-        }
-    }
-
-    private static File prepareBinaries(PgBinaryResolver pgBinaryResolver, Optional<File> overrideWorkingDirectory)
-    {
-        PREPARE_BINARIES_LOCK.lock();
-        try {
-            if (PREPARE_BINARIES.containsKey(pgBinaryResolver) && PREPARE_BINARIES.get(pgBinaryResolver).exists()) {
-                return PREPARE_BINARIES.get(pgBinaryResolver);
-            }
-
-            final String system = getOS();
-            final String machineHardware = getArchitecture();
-
-            LOG.info("Detected a {} {} system", system, machineHardware);
-            File pgDir;
-            final InputStream pgBinary; //NOPMD
-            try {
-                pgBinary = pgBinaryResolver.getPgBinary(system, machineHardware);
-            } catch (final IOException e) {
-                throw new ExceptionInInitializerError(e);
-            }
-
-            if (pgBinary == null) {
-                throw new IllegalStateException("No Postgres binary found for " + system + " / " + machineHardware);
-            }
-
-            try (DigestInputStream pgArchiveData = new DigestInputStream(pgBinary, MessageDigest.getInstance("MD5"));
-                 ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-                IOUtils.copy(pgArchiveData, baos);
-                pgArchiveData.close();
-
-                String pgDigest = Hex.encodeHexString(pgArchiveData.getMessageDigest().digest());
-                File workingDirectory = overrideWorkingDirectory.isPresent() ? overrideWorkingDirectory.get() : getWorkingDirectory();
-                pgDir = new File(workingDirectory, String.format("PG-%s", pgDigest));
-
-                mkdirs(pgDir);
-                final File unpackLockFile = new File(pgDir, LOCK_FILE_NAME);
-                final File pgDirExists = new File(pgDir, ".exists");
-
-                if (!pgDirExists.exists()) {
-                    try (FileOutputStream lockStream = new FileOutputStream(unpackLockFile);
-                         FileLock unpackLock = lockStream.getChannel().tryLock()) {
-                        if (unpackLock != null) {
-                            try {
-                                if (pgDirExists.exists()) {
-                                    throw new IllegalStateException("unpack lock acquired but .exists file is present " + pgDirExists);
-                                }
-                                LOG.info("Extracting Postgres...");
-                                try (ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray())) {
-                                    extractTxz(bais, pgDir.getPath());
-                                }
-                                if (!pgDirExists.createNewFile()) {
-                                    throw new IllegalStateException("couldn't make .exists file " + pgDirExists);
-                                }
-                            } catch (Exception e) {
-                                LOG.error("while unpacking Postgres", e);
-                            }
-                        } else {
-                            // the other guy is unpacking for us.
-                            int maxAttempts = 60;
-                            while (!pgDirExists.exists() && --maxAttempts > 0) { //NOPMD
-                                Thread.sleep(1000L);
-                            }
-                            if (!pgDirExists.exists()) {
-                                throw new IllegalStateException("Waited 60 seconds for postgres to be unpacked but it never finished!");
-                            }
-                        }
-                    } finally {
-                        if (unpackLockFile.exists() && !unpackLockFile.delete()) {
-                            LOG.error("could not remove lock file {}", unpackLockFile.getAbsolutePath());
-                        }
-                    }
-                }
-            } catch (final IOException | NoSuchAlgorithmException e) {
-                throw new ExceptionInInitializerError(e);
-            } catch (final InterruptedException ie) {
-                Thread.currentThread().interrupt();
-                throw new ExceptionInInitializerError(ie);
-            }
-            PREPARE_BINARIES.put(pgBinaryResolver, pgDir);
-            LOG.info("Postgres binaries at {}", pgDir);
-            return pgDir;
-        } finally {
-            PREPARE_BINARIES_LOCK.unlock();
-        }
-    }
-
+    
     @Override
-    public String toString()
-    {
+    public String toString() {
         return "EmbeddedPG-" + instanceId;
     }
 }

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -119,9 +119,6 @@ public class EmbeddedPostgres implements Closeable
         this.errorRedirector = errorRedirector;
         this.outputRedirector = outputRedirector;
         this.pgStartupWait = Objects.requireNonNull(pgStartupWait, "Wait time cannot be null");
-        ;
-
-
         if (parentDirectory != null) {
             mkdirs(parentDirectory);
             cleanOldDataDirectories(parentDirectory);
@@ -610,7 +607,6 @@ public class EmbeddedPostgres implements Closeable
         }
     }
 
-    
     @Override
     public String toString() {
         return "EmbeddedPG-" + instanceId;

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -133,7 +133,7 @@ public class EmbeddedPostgres implements Closeable
         if (this.dataDirectory == null) {
             throw new IllegalArgumentException("no data directory");
         }
-        LOG.info("{} postgres: data directory is {}, postgres directory is {}", instanceId, this.dataDirectory, this.pgDir);
+        LOG.debug("{} postgres: data directory is {}, postgres directory is {}", instanceId, this.dataDirectory, this.pgDir);
         mkdirs(this.dataDirectory);
 
         lockFile = new File(this.dataDirectory, LOCK_FILE_NAME);
@@ -548,6 +548,7 @@ public class EmbeddedPostgres implements Closeable
                 builderDataDirectory = Files.createTempDirectory("epg").toFile();
             }
             if (pgDirectoryResolver == null) {
+                LOG.trace("pgDirectoryResolver not overriden, using default (UncompressBundleDirectoryResolver)");
                 pgDirectoryResolver = UncompressBundleDirectoryResolver.getDefault();
             }
             return new EmbeddedPostgres(parentDirectory, builderDataDirectory, builderCleanDataDirectory, config,

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedUtil.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedUtil.java
@@ -44,7 +44,7 @@ final class EmbeddedUtil {
     static final String PG_SUPERUSER = "postgres";
     static final Duration DEFAULT_PG_STARTUP_WAIT = Duration.ofSeconds(10);
     static final String LOCK_FILE_NAME = "epg-lock";
-    
+
     private EmbeddedUtil() {}
 
     static File getWorkingDirectory() {

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedUtil.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedUtil.java
@@ -77,7 +77,6 @@ final class EmbeddedUtil {
         }
         throw new UnsupportedOperationException("Unknown OS " + SystemUtils.OS_NAME);
     }
-    
 
     /**
      * Get the machine architecture string. The string is used in the appropriate
@@ -161,6 +160,4 @@ final class EmbeddedUtil {
             phaser.arriveAndAwaitAdvance();
         }
     }
-
-
 }

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedUtil.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedUtil.java
@@ -36,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tukaani.xz.XZInputStream;
 
-class EmbeddedUtil {
+final class EmbeddedUtil {
     static final Logger LOG = LoggerFactory.getLogger(EmbeddedPostgres.class);
     static final String JDBC_FORMAT = "jdbc:postgresql://localhost:%s/%s?user=%s";
     static final String PG_STOP_MODE = "fast";
@@ -44,7 +44,8 @@ class EmbeddedUtil {
     static final String PG_SUPERUSER = "postgres";
     static final Duration DEFAULT_PG_STARTUP_WAIT = Duration.ofSeconds(10);
     static final String LOCK_FILE_NAME = "epg-lock";
-
+    
+    private EmbeddedUtil() {}
 
     static File getWorkingDirectory() {
         final File tempWorkingDirectory = new File(System.getProperty("java.io.tmpdir"), "embedded-pg");

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedUtil.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedUtil.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.db.postgres.embedded;
+
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.WRITE;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousFileChannel;
+import java.nio.channels.Channel;
+import java.nio.channels.CompletionHandler;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.concurrent.Phaser;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.lang3.SystemUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tukaani.xz.XZInputStream;
+
+class EmbeddedUtil {
+    static final Logger LOG = LoggerFactory.getLogger(EmbeddedPostgres.class);
+    static final String JDBC_FORMAT = "jdbc:postgresql://localhost:%s/%s?user=%s";
+    static final String PG_STOP_MODE = "fast";
+    static final String PG_STOP_WAIT_S = "5";
+    static final String PG_SUPERUSER = "postgres";
+    static final Duration DEFAULT_PG_STARTUP_WAIT = Duration.ofSeconds(10);
+    static final String LOCK_FILE_NAME = "epg-lock";
+
+
+    static File getWorkingDirectory() {
+        final File tempWorkingDirectory = new File(System.getProperty("java.io.tmpdir"), "embedded-pg");
+        return new File(System.getProperty("ot.epg.working-dir", tempWorkingDirectory.getPath()));
+    }
+
+
+    static void mkdirs(File dir) {
+        if (!dir.mkdirs() && !(dir.isDirectory() && dir.exists())) {
+            throw new IllegalStateException("could not create " + dir);
+        }
+    }
+
+    /**
+     * Get current operating system string. The string is used in the appropriate
+     * postgres binary name.
+     *
+     * @return Current operating system string.
+     */
+    static String getOS() {
+        if (SystemUtils.IS_OS_WINDOWS) {
+            return "Windows";
+        }
+        if (SystemUtils.IS_OS_MAC_OSX) {
+            return "Darwin";
+        }
+        if (SystemUtils.IS_OS_LINUX) {
+            return "Linux";
+        }
+        throw new UnsupportedOperationException("Unknown OS " + SystemUtils.OS_NAME);
+    }
+    
+
+    /**
+     * Get the machine architecture string. The string is used in the appropriate
+     * postgres binary name.
+     *
+     * @return Current machine architecture string.
+     */
+    static String getArchitecture() {
+        return "amd64".equals(SystemUtils.OS_ARCH) ? "x86_64" : SystemUtils.OS_ARCH;
+    }
+
+    /**
+     * Unpack archive compressed by tar with xz compression. By default system tar is used (faster). If not found, then the
+     * java implementation takes place.
+     *
+     * @param stream    A stream with the postgres binaries.
+     * @param targetDir The directory to extract the content to.
+     */
+    static void extractTxz(InputStream stream, String targetDir) throws IOException {
+        try (
+                XZInputStream xzIn = new XZInputStream(stream);
+                TarArchiveInputStream tarIn = new TarArchiveInputStream(xzIn)
+        ) {
+            final Phaser phaser = new Phaser(1);
+            TarArchiveEntry entry;
+
+            while ((entry = tarIn.getNextTarEntry()) != null) { //NOPMD
+                final String individualFile = entry.getName();
+                final File fsObject = new File(targetDir, individualFile);
+
+                if (entry.isSymbolicLink() || entry.isLink()) {
+                    Path target = FileSystems.getDefault().getPath(entry.getLinkName());
+                    Files.createSymbolicLink(fsObject.toPath(), target);
+                } else if (entry.isFile()) {
+                    byte[] content = new byte[(int) entry.getSize()];
+                    int read = tarIn.read(content, 0, content.length);
+                    if (read == -1) {
+                        throw new IllegalStateException("could not read " + individualFile);
+                    }
+                    mkdirs(fsObject.getParentFile());
+
+                    final AsynchronousFileChannel fileChannel = AsynchronousFileChannel.open(fsObject.toPath(), CREATE, WRITE); //NOPMD
+                    final ByteBuffer buffer = ByteBuffer.wrap(content); //NOPMD
+
+                    phaser.register();
+                    fileChannel.write(buffer, 0, fileChannel, new CompletionHandler<Integer, Channel>() {
+                        @Override
+                        public void completed(Integer written, Channel channel) {
+                            closeChannel(channel);
+                        }
+
+                        @Override
+                        public void failed(Throwable error, Channel channel) {
+                            LOG.error("Could not write file {}", fsObject.getAbsolutePath(), error);
+                            closeChannel(channel);
+                        }
+
+                        private void closeChannel(Channel channel) {
+                            try {
+                                channel.close();
+                            } catch (IOException e) {
+                                LOG.error("Unexpected error while closing the channel", e);
+                            } finally {
+                                phaser.arriveAndDeregister();
+                            }
+                        }
+                    });
+                } else if (entry.isDirectory()) {
+                    mkdirs(fsObject);
+                } else {
+                    throw new UnsupportedOperationException(
+                            String.format("Unsupported entry found: %s", individualFile)
+                    );
+                }
+
+                if (individualFile.startsWith("bin/") || individualFile.startsWith("./bin/")) {
+                    fsObject.setExecutable(true);
+                }
+            }
+
+            phaser.arriveAndAwaitAdvance();
+        }
+    }
+
+
+}

--- a/src/main/java/com/opentable/db/postgres/embedded/PgDirectoryResolver.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/PgDirectoryResolver.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.db.postgres.embedded;
+
+import java.io.File;
+import java.util.Optional;
+
+@FunctionalInterface
+public interface PgDirectoryResolver {
+    File getDirectory(Optional<File> overrideWorkingDirectory);
+}

--- a/src/main/java/com/opentable/db/postgres/embedded/UncompressBundleDirectoryResolver.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/UncompressBundleDirectoryResolver.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.db.postgres.embedded;
+
+import static com.opentable.db.postgres.embedded.EmbeddedUtil.LOCK_FILE_NAME;
+import static com.opentable.db.postgres.embedded.EmbeddedUtil.extractTxz;
+import static com.opentable.db.postgres.embedded.EmbeddedUtil.getArchitecture;
+import static com.opentable.db.postgres.embedded.EmbeddedUtil.getOS;
+import static com.opentable.db.postgres.embedded.EmbeddedUtil.getWorkingDirectory;
+import static com.opentable.db.postgres.embedded.EmbeddedUtil.mkdirs;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.FileLock;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UncompressBundleDirectoryResolver implements PgDirectoryResolver {
+
+    private static volatile UncompressBundleDirectoryResolver DEFAULT_INSTANCE;
+
+    public static synchronized UncompressBundleDirectoryResolver getDefault() {
+        if (DEFAULT_INSTANCE == null) {
+            DEFAULT_INSTANCE = new UncompressBundleDirectoryResolver(new BundledPostgresBinaryResolver());
+        }
+        return DEFAULT_INSTANCE;
+    }
+
+    private static final Logger LOG = LoggerFactory.getLogger(EmbeddedPostgres.class);
+    private final Lock prepareBinariesLock = new ReentrantLock();
+
+    private final PgBinaryResolver pgBinaryResolver;
+
+    public UncompressBundleDirectoryResolver(PgBinaryResolver pgBinaryResolver) {
+        this.pgBinaryResolver = pgBinaryResolver;
+    }
+
+    private final Map<PgBinaryResolver, File> prepareBinaries = new HashMap<>();
+
+    @Override
+    public File getDirectory(Optional<File> overrideWorkingDirectory) {
+        prepareBinariesLock.lock();
+        try {
+            if (prepareBinaries.containsKey(pgBinaryResolver)) {
+                return prepareBinaries.get(pgBinaryResolver);
+            }
+
+            final String system = getOS();
+            final String machineHardware = getArchitecture();
+
+            LOG.info("Detected a {} {} system", system, machineHardware);
+            File pgDir;
+            final InputStream pgBinary; // NOPMD
+            try {
+                pgBinary = pgBinaryResolver.getPgBinary(system, machineHardware);
+            } catch (final IOException e) {
+                throw new ExceptionInInitializerError(e);
+            }
+
+            if (pgBinary == null) {
+                throw new IllegalStateException("No Postgres binary found for " + system + " / " + machineHardware);
+            }
+
+            try (DigestInputStream pgArchiveData = new DigestInputStream(pgBinary, MessageDigest.getInstance("MD5"));
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                IOUtils.copy(pgArchiveData, baos);
+                pgArchiveData.close();
+
+                String pgDigest = Hex.encodeHexString(pgArchiveData.getMessageDigest().digest());
+                File workingDirectory = overrideWorkingDirectory.isPresent() ? overrideWorkingDirectory.get()
+                        : getWorkingDirectory();
+                pgDir = new File(workingDirectory, String.format("PG-%s", pgDigest));
+
+                mkdirs(pgDir);
+                final File unpackLockFile = new File(pgDir, LOCK_FILE_NAME);
+                final File pgDirExists = new File(pgDir, ".exists");
+
+                if (!pgDirExists.exists()) {
+                    try (FileOutputStream lockStream = new FileOutputStream(unpackLockFile);
+                            FileLock unpackLock = lockStream.getChannel().tryLock()) {
+                        if (unpackLock != null) {
+                            try {
+                                if (pgDirExists.exists()) {
+                                    throw new IllegalStateException(
+                                            "unpack lock acquired but .exists file is present " + pgDirExists);
+                                }
+                                LOG.info("Extracting Postgres...");
+                                try (ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray())) {
+                                    extractTxz(bais, pgDir.getPath());
+                                }
+                                if (!pgDirExists.createNewFile()) {
+                                    throw new IllegalStateException("couldn't make .exists file " + pgDirExists);
+                                }
+                            } catch (Exception e) {
+                                LOG.error("while unpacking Postgres", e);
+                            }
+                        } else {
+                            // the other guy is unpacking for us.
+                            int maxAttempts = 60;
+                            while (!pgDirExists.exists() && --maxAttempts > 0) { // NOPMD
+                                Thread.sleep(1000L);
+                            }
+                            if (!pgDirExists.exists()) {
+                                throw new IllegalStateException(
+                                        "Waited 60 seconds for postgres to be unpacked but it never finished!");
+                            }
+                        }
+                    } finally {
+                        if (unpackLockFile.exists() && !unpackLockFile.delete()) {
+                            LOG.error("could not remove lock file {}", unpackLockFile.getAbsolutePath());
+                        }
+                    }
+                }
+            } catch (final IOException | NoSuchAlgorithmException e) {
+                throw new ExceptionInInitializerError(e);
+            } catch (final InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new ExceptionInInitializerError(ie);
+            }
+            prepareBinaries.put(pgBinaryResolver, pgDir);
+            LOG.info("Postgres binaries at {}", pgDir);
+            return pgDir;
+        } finally {
+            prepareBinariesLock.unlock();
+        }
+    }
+}

--- a/src/main/java/com/opentable/db/postgres/embedded/UncompressBundleDirectoryResolver.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/UncompressBundleDirectoryResolver.java
@@ -67,7 +67,7 @@ public class UncompressBundleDirectoryResolver implements PgDirectoryResolver {
     public File getDirectory(Optional<File> overrideWorkingDirectory) {
         prepareBinariesLock.lock();
         try {
-            if (prepareBinaries.containsKey(pgBinaryResolver)) {
+            if (prepareBinaries.containsKey(pgBinaryResolver) && prepareBinaries.get(pgBinaryResolver).exists()) {
                 return prepareBinaries.get(pgBinaryResolver);
             }
 

--- a/src/test/java/com/opentable/db/postgres/embedded/LocalDirectoryPostgresTest.java
+++ b/src/test/java/com/opentable/db/postgres/embedded/LocalDirectoryPostgresTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.db.postgres.embedded;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+@Ignore("Only works with /usr/local postgres")
+public class LocalDirectoryPostgresTest {
+    
+    @Test
+    public void testEmbeddedPg() throws Exception {
+        try (EmbeddedPostgres pg = EmbeddedPostgres.builder().setPostgresBinaryDirectory(new File("/usr/local"))
+                .start(); Connection c = pg.getPostgresDatabase().getConnection()) {
+            Statement s = c.createStatement();
+            ResultSet rs = s.executeQuery("SELECT 1");
+            assertTrue(rs.next());
+            assertEquals(1, rs.getInt(1));
+            assertFalse(rs.next());
+        }
+    }
+}

--- a/src/test/java/com/opentable/db/postgres/embedded/LocalDirectoryPostgresTest.java
+++ b/src/test/java/com/opentable/db/postgres/embedded/LocalDirectoryPostgresTest.java
@@ -22,16 +22,19 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.Statement;
 
-import org.junit.Ignore;
+import org.junit.Assume;
 import org.junit.Test;
 
-@Ignore("Only works with /usr/local postgres")
 public class LocalDirectoryPostgresTest {
-    
+
+    private static final File USR_LOCAL = new File("/usr/local");
+    private static final File USR_LOCAL_BIN_POSTGRES = new File("/usr/local/bin/postgres");
+
     @Test
     public void testEmbeddedPg() throws Exception {
-        try (EmbeddedPostgres pg = EmbeddedPostgres.builder().setPostgresBinaryDirectory(new File("/usr/local"))
-                .start(); Connection c = pg.getPostgresDatabase().getConnection()) {
+        Assume.assumeTrue("PostgreSQL binary must exist", USR_LOCAL_BIN_POSTGRES.exists());
+        try (EmbeddedPostgres pg = EmbeddedPostgres.builder().setPostgresBinaryDirectory(USR_LOCAL).start();
+                Connection c = pg.getPostgresDatabase().getConnection()) {
             Statement s = c.createStatement();
             ResultSet rs = s.executeQuery("SELECT 1");
             assertTrue(rs.next());


### PR DESCRIPTION
(New version of older PR #90 )

This PR basically separates the handling of the embedded dir in a directory provider interface (PgDirectoryResolver), and moves all logic to handle existing bundles from the main class to a separate one (UncompressBundleDirectoryResolver ) which implements the PgDirectoryResolver interface.

Eg:
```java
EmbeddedPostgres pg = EmbeddedPostgres.builder().setPostgresBinaryDirectory(new File("/usr/local")).start();
```

This way I can use the postgres setup installed in /usr/local (with `brew install`), allowing me to use postgis extension among others (workaround for #29 )

