### PR TITLE
Make Darwin bundle fully self-contained by including libpq

### DIFF
--- a/repack-postgres.sh
+++ b/repack-postgres.sh
@@ -42,6 +42,7 @@ tar cJf $RSRC_DIR/postgresql-Darwin-x86_64.txz \
   lib/libssl.1.0.0.dylib \
   lib/libcrypto.1.0.0.dylib \
   lib/libuuid.1.1.dylib \
+  lib/libpq.5.dylib \
   lib/postgresql/*.so \
   bin/initdb \
   bin/pg_ctl \


### PR DESCRIPTION
libpq is the C Postgres client library. It is used by bin/initdb which is
packaged and run by this project.

While the Linux and Windows tarballs contain libpq, the Mac (Darwin) one does
not. This mostly works out ok because Macs ship with /usr/lib/libpq.5.dylib (and
you can install your own libpq to other places like /usr/local/lib with, eg,
Homebrew), but this might be a surprising version or may be misinstalled. (I
discovered this problem when my Homebrew Postgres installation was misinstalled
and it broke EmbeddedPostgres.)

By packaging libpq with the Darwin bundle, EmbeddedPostgres can be fully
self-contained on Mac.

You can verify this as follows:

    ./repack-postgres.sh
    mkdir unpacked
    cd unpacked
    tar xJf ../target/generated-resources/postgresql-Darwin-x86_64.txz
    DYLD_PRINT_LIBRARIES=YES ./bin/initdb --version 2>&1 | grep libpq

Before this change, the final command reads:

    dyld: loaded: /usr/lib/libpq.5.dylib

After this change, it reads:

    dyld: loaded: /private/tmp/otj-pg-embedded/unpacked/./bin/../lib/libpq.5.dylib