### PR TITLE
made prettier format of process's command on exception

### DIFF
--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -599,7 +599,7 @@ public class EmbeddedPostgres implements Closeable
                 ProcessOutputLogger.logOutput(LoggerFactory.getLogger(LOG_PREFIX + "init-" + instanceId + ":" + FilenameUtils.getName(command[0])), process);
             }
             if (0 != process.waitFor()) {
-                throw new IllegalStateException(String.format("Process %s failed%n%s", Arrays.asList(command), IOUtils.toString(process.getErrorStream(), StandardCharsets.UTF_8)));
+                throw new IllegalStateException(String.format("Process [%s] failed%n%s", String.join(" ", command), IOUtils.toString(process.getErrorStream(), StandardCharsets.UTF_8)));
             }
         } catch (final RuntimeException e) { // NOPMD
             throw e;


### PR DESCRIPTION
**It was inconvenient to run the failed command in the terminal emulator, because the log contained commas.**
---
It looked like this before:
```
java.lang.IllegalStateException: Process [/var/folders/g_/test/T/embedded-pg/test/bin/initdb, -A, trust, -U, postgres, -D, /var/folders/g_/test/T/test, -E, UTF-8] failed
```
And it will be looks like this now:
```
java.lang.IllegalStateException: Process [/var/folders/g_/test/T/embedded-pg/test/bin/initdb -A trust -U postgres -D /var/folders/g_/test/T/test -E UTF-8] failed
```