### PR TITLE
Split from otj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.0.3 (unreleased) 
+----
+* commons compress 1.24.0 (used by testcontainers) updated for a CVE.
+* testcontainers 1.19.0
+
 1.0.2
 -----
 * Internally split off from otj-parent to allow compatibility between different otj stacks and not pull as much otj-ness.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.0.2
+-----
+* Internally split off from otj-parent to allow compatibility between different otj stacks and not pull as much otj-ness.
+
 1.0.1
 -----
 * Parent POM-328 [changes see here]( https://github.com/opentable/otj-parent/blob/master/CHANGELOG.md#328)

--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,12 @@
     <connection>scm:git:git://github.com/opentable/otj-pg-embedded.git</connection>
     <developerConnection>scm:git:git@github.com:opentable/otj-pg-embedded.git</developerConnection>
     <url>http://github.com/opentable/otj-pg-embedded</url>
-    <tag>HEAD</tag>
+    <tag>otj-pg-embedded-another-test-3</tag>
   </scm>
 
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-pg-embedded</artifactId>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>another-test-3</version>
   <description>Embedded PostgreSQL driver</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,12 @@
     <connection>scm:git:git://github.com/opentable/otj-pg-embedded.git</connection>
     <developerConnection>scm:git:git@github.com:opentable/otj-pg-embedded.git</developerConnection>
     <url>http://github.com/opentable/otj-pg-embedded</url>
-    <tag>HEAD</tag>
+    <tag>otj-pg-embedded-1.0.2</tag>
   </scm>
 
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-pg-embedded</artifactId>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>1.0.2</version>
   <description>Embedded PostgreSQL driver</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,12 @@
     <connection>scm:git:git://github.com/opentable/otj-pg-embedded.git</connection>
     <developerConnection>scm:git:git@github.com:opentable/otj-pg-embedded.git</developerConnection>
     <url>http://github.com/opentable/otj-pg-embedded</url>
-    <tag>HEAD</tag>
+    <tag>otj-pg-embedded-test-release-1</tag>
   </scm>
 
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-pg-embedded</artifactId>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>test-release-1</version>
   <description>Embedded PostgreSQL driver</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,12 @@
     <connection>scm:git:git://github.com/opentable/otj-pg-embedded.git</connection>
     <developerConnection>scm:git:git@github.com:opentable/otj-pg-embedded.git</developerConnection>
     <url>http://github.com/opentable/otj-pg-embedded</url>
-    <tag>HEAD</tag>
+    <tag>otj-pg-embedded-another-test-4</tag>
   </scm>
 
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-pg-embedded</artifactId>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>another-test-4</version>
   <description>Embedded PostgreSQL driver</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -295,22 +295,22 @@
             </executions>
           </plugin>
           <!-- if necessary, build a scaladoc jar. Disabled by default. -->
-          <plugin>
-            <groupId>net.alchim31.maven</groupId>
-            <artifactId>scala-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>attach-scaladocs</id>
-                <phase>package</phase>
-                <configuration>
-                  <skip>${basepom.oss.skip-scala-doc}</skip>
-                </configuration>
-                <goals>
-                  <goal>doc-jar</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
+<!--          <plugin>-->
+<!--            <groupId>net.alchim31.maven</groupId>-->
+<!--            <artifactId>scala-maven-plugin</artifactId>-->
+<!--            <executions>-->
+<!--              <execution>-->
+<!--                <id>attach-scaladocs</id>-->
+<!--                <phase>package</phase>-->
+<!--                <configuration>-->
+<!--                  <skip>${basepom.oss.skip-scala-doc}</skip>-->
+<!--                </configuration>-->
+<!--                <goals>-->
+<!--                  <goal>doc-jar</goal>-->
+<!--                </goals>-->
+<!--              </execution>-->
+<!--            </executions>-->
+<!--          </plugin>-->
           <!-- Sign artifacts using gpg for oss upload -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,9 +18,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.opentable</groupId>
-    <artifactId>otj-parent-spring</artifactId>
-    <version>328</version>
+    <groupId>org.basepom</groupId>
+    <artifactId>basepom-minimal</artifactId>
+    <version>55</version>
   </parent>
 
   <scm>
@@ -36,9 +36,18 @@
   <description>Embedded PostgreSQL driver</description>
 
   <properties>
-    <!-- Remove once parent POM updated -->
-    <dep.testcontainers.version>1.16.3</dep.testcontainers.version>
-    <!-- end remove -->
+    <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
+    <project.build.targetJdk>11</project.build.targetJdk>
+    <maven.compiler.target>${project.build.targetJdk}</maven.compiler.target>
+    <project.build.systemJdk>${project.build.targetJdk}</project.build.systemJdk>
+    <dep.testcontainers.version>1.18.3</dep.testcontainers.version>
+    <dep.postgres-jdbc.version>42.5.1</dep.postgres-jdbc.version>
+    <dep.liquibase.version>4.23.1</dep.liquibase.version>
+    <dep.slf4j.version>1.7.36</dep.slf4j.version>
+    <dep.flyway.version>8.5.13</dep.flyway.version>
+    <dep.commons-lang.version>3.12.0</dep.commons-lang.version>
+    <dep.junit.version>4.13.2</dep.junit.version>
+    <dep.junit5.version>5.8.2</dep.junit5.version>
     <basepom.test.timeout>1800</basepom.test.timeout>
     <basepom.oss.skip-scala-doc>true</basepom.oss.skip-scala-doc>
     <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
@@ -58,28 +67,33 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <version>${dep.slf4j.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+      <version>${dep.commons-lang.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.flywaydb</groupId>
       <artifactId>flyway-core</artifactId>
       <optional>true</optional>
+      <version>${dep.flyway.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.liquibase</groupId>
       <artifactId>liquibase-core</artifactId>
+      <version>${dep.liquibase.version}</version>
       <optional>true</optional>
     </dependency>
 
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
+      <version>${dep.postgres-jdbc.version}</version>
     </dependency>
 
     <dependency>
@@ -94,6 +108,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <version>${dep.junit.version}</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
@@ -101,6 +116,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
+      <version>${dep.junit5.version}</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
@@ -108,6 +124,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
+      <version>${dep.slf4j.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
   <description>Embedded PostgreSQL driver</description>
 
   <properties>
+    <dep.plugin.gpg.version>3.1.0</dep.plugin.gpg.version>
     <dep.plugin.license.version>4.2</dep.plugin.license.version>
     <basepom.check.phase-license>validate</basepom.check.phase-license> <!-- this is overriding basepom default -->
     <basepom.license.skip-existing>true</basepom.license.skip-existing>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,13 @@
   <description>Embedded PostgreSQL driver</description>
 
   <properties>
+    <dep.plugin.license.version>4.2</dep.plugin.license.version>
+    <basepom.check.phase-license>validate</basepom.check.phase-license> <!-- this is overriding basepom default -->
+    <basepom.license.skip-existing>true</basepom.license.skip-existing>
+    <basepom.release.profiles>basepom.oss-release,oss-build</basepom.release.profiles>
+
+    <basepom.check.skip-license>${basepom.check.skip-extended}</basepom.check.skip-license>
+    <basepom.check.fail-license>${basepom.check.fail-extended}</basepom.check.fail-license>
     <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
     <project.build.targetJdk>11</project.build.targetJdk>
     <maven.compiler.target>${project.build.targetJdk}</maven.compiler.target>
@@ -143,5 +150,125 @@
        </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <profiles>
+    <profile>
+      <id>oss-build</id>
+      <activation>
+        <file>
+          <exists>.oss-build</exists>
+        </file>
+      </activation>
+
+      <!-- note the main difference is released artifacts go to oss.sonatype instead of internal -->
+      <distributionManagement>
+        <snapshotRepository>
+          <id>opentable.snapshot</id>
+          <name>opentable-snapshots</name>
+          <uniqueVersion>true</uniqueVersion>
+          <url>https://artifactory.otenv.com/snapshots</url>
+        </snapshotRepository>
+        <repository>
+          <id>sonatype-nexus-staging</id>
+          <name>Nexus Release Repository</name>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+      </distributionManagement>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-release-plugin</artifactId>
+              <configuration>
+                <!-- activate some basepom stuff, this binds the profile below -->
+                <releaseProfiles>${basepom.release.profiles}</releaseProfiles>
+              </configuration>
+            </plugin>
+
+            <!-- checks for valid OSS license stuff and headers -->
+            <plugin>
+              <groupId>com.mycila</groupId>
+              <artifactId>license-maven-plugin</artifactId>
+              <version>${dep.plugin.license.version}</version>
+              <dependencies>
+                <dependency>
+                  <groupId>org.basepom</groupId>
+                  <artifactId>basepom-policy</artifactId>
+                  <version>${dep.basepom-policy.version}</version>
+                </dependency>
+              </dependencies>
+              <configuration>
+                <skip>${basepom.check.skip-license}</skip>
+                <skipExistingHeaders>${basepom.license.skip-existing}</skipExistingHeaders>
+                <failIfMissing>${basepom.check.fail-license}</failIfMissing>
+                <header>license/basepom-apache-license-header.txt</header>
+                <headerDefinitions>
+                  <headerDefinition>license/xml-prefix.xml</headerDefinition>
+                </headerDefinitions>
+                <mapping>
+                  <xml>XML_PREFIX</xml>
+                  <java>SLASHSTAR_STYLE</java>
+                  <yaml>SCRIPT_STYLE</yaml>
+                </mapping>
+                <strictCheck>true</strictCheck>
+                <aggregate>true</aggregate>
+                <useDefaultExcludes>true</useDefaultExcludes>
+                <encoding>${project.build.sourceEncoding}</encoding>
+                <excludes>
+                  <exclude>.*/**</exclude>
+                  <exclude>**/*.md</exclude>
+                  <exclude>**/*.rst</exclude>
+                  <exclude>**/*.adoc</exclude>
+                  <exclude>**/*.sh</exclude>
+                  <exclude>**/*.txt</exclude>
+                  <exclude>**/*.thrift</exclude>
+                  <exclude>**/*.proto</exclude>
+                  <exclude>**/*.g</exclude>
+                  <exclude>**/*.releaseBackup</exclude>
+                  <exclude>**/*.vm</exclude>
+                  <exclude>**/*.st</exclude>
+                  <exclude>**/*.raw</exclude>
+                  <exclude>**/*.ser</exclude>
+                  <exclude>**/src/license/**</exclude>
+                </excludes>
+                <includes>
+                  <include>src/**</include>
+                  <include>**/pom.xml</include>
+                </includes>
+              </configuration>
+            </plugin>
+
+            <!-- sign with gpg -->
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-gpg-plugin</artifactId>
+              <version>${dep.plugin.gpg.version}</version>
+              <configuration>
+                <useAgent>true</useAgent>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+
+        <!-- more license checking. One day I'll know why both of these -->
+        <plugins>
+          <plugin>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>basepom.default</id>
+                <phase>${basepom.check.phase-license}</phase>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,12 @@
     <connection>scm:git:git://github.com/opentable/otj-pg-embedded.git</connection>
     <developerConnection>scm:git:git@github.com:opentable/otj-pg-embedded.git</developerConnection>
     <url>http://github.com/opentable/otj-pg-embedded</url>
-    <tag>otj-pg-embedded-1.0.2</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-pg-embedded</artifactId>
-  <version>1.0.2</version>
+  <version>1.0.3-SNAPSHOT</version>
   <description>Embedded PostgreSQL driver</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-pg-embedded</artifactId>
-  <version>1.1-SNAPSHOT</version>
+  <version>1.0.2-SNAPSHOT</version>
   <description>Embedded PostgreSQL driver</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,64 @@
         </plugins>
       </build>
     </profile>
+
+    <!-- Active during OSS release:perform -->
+    <profile>
+      <id>basepom.oss-release</id>
+      <properties>
+        <!-- tests run in the preparation step of the release -->
+        <skipTests>true</skipTests>
+      </properties>
+      <build>
+        <plugins>
+          <!-- oss requires a javadoc jar. Build one when releasing. -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- if necessary, build a scaladoc jar. Disabled by default. -->
+          <plugin>
+            <groupId>net.alchim31.maven</groupId>
+            <artifactId>scala-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-scaladocs</id>
+                <phase>package</phase>
+                <configuration>
+                  <skip>${basepom.oss.skip-scala-doc}</skip>
+                </configuration>
+                <goals>
+                  <goal>doc-jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- Sign artifacts using gpg for oss upload -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>basepom.sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -48,12 +48,13 @@
     <project.build.targetJdk>11</project.build.targetJdk>
     <maven.compiler.target>${project.build.targetJdk}</maven.compiler.target>
     <project.build.systemJdk>${project.build.targetJdk}</project.build.systemJdk>
-    <dep.testcontainers.version>1.18.3</dep.testcontainers.version>
+    <dep.testcontainers.version>1.19.0</dep.testcontainers.version>
     <dep.postgres-jdbc.version>42.5.1</dep.postgres-jdbc.version>
     <dep.liquibase.version>4.23.1</dep.liquibase.version>
     <dep.slf4j.version>1.7.36</dep.slf4j.version>
     <dep.flyway.version>8.5.13</dep.flyway.version>
     <dep.commons-lang.version>3.12.0</dep.commons-lang.version>
+    <dep.commons-compress.version>1.24.0</dep.commons-compress.version>
     <dep.junit.version>4.13.2</dep.junit.version>
     <dep.junit5.version>5.8.2</dep.junit5.version>
     <basepom.test.timeout>1800</basepom.test.timeout>
@@ -83,6 +84,12 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>${dep.commons-lang.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>${dep.commons-compress.version}</version>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,12 @@
     <connection>scm:git:git://github.com/opentable/otj-pg-embedded.git</connection>
     <developerConnection>scm:git:git@github.com:opentable/otj-pg-embedded.git</developerConnection>
     <url>http://github.com/opentable/otj-pg-embedded</url>
-    <tag>otj-pg-embedded-another-test-3</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-pg-embedded</artifactId>
-  <version>another-test-3</version>
+  <version>1.0.2-SNAPSHOT</version>
   <description>Embedded PostgreSQL driver</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,12 @@
     <connection>scm:git:git://github.com/opentable/otj-pg-embedded.git</connection>
     <developerConnection>scm:git:git@github.com:opentable/otj-pg-embedded.git</developerConnection>
     <url>http://github.com/opentable/otj-pg-embedded</url>
-    <tag>otj-pg-embedded-test-release-1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-pg-embedded</artifactId>
-  <version>test-release-1</version>
+  <version>1.1-SNAPSHOT</version>
   <description>Embedded PostgreSQL driver</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,12 @@
     <connection>scm:git:git://github.com/opentable/otj-pg-embedded.git</connection>
     <developerConnection>scm:git:git@github.com:opentable/otj-pg-embedded.git</developerConnection>
     <url>http://github.com/opentable/otj-pg-embedded</url>
-    <tag>HEAD</tag>
+    <tag>otj-pg-embedded-another-test-5</tag>
   </scm>
 
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-pg-embedded</artifactId>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>another-test-5</version>
   <description>Embedded PostgreSQL driver</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <dep.junit.version>4.13.2</dep.junit.version>
     <dep.junit5.version>5.8.2</dep.junit5.version>
     <basepom.test.timeout>1800</basepom.test.timeout>
+    <basepom.javadoc.skip>false</basepom.javadoc.skip>
     <basepom.oss.skip-scala-doc>true</basepom.oss.skip-scala-doc>
     <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
     <basepom.check.fail-javadoc>false</basepom.check.fail-javadoc>

--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,12 @@
     <connection>scm:git:git://github.com/opentable/otj-pg-embedded.git</connection>
     <developerConnection>scm:git:git@github.com:opentable/otj-pg-embedded.git</developerConnection>
     <url>http://github.com/opentable/otj-pg-embedded</url>
-    <tag>otj-pg-embedded-another-test-5</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-pg-embedded</artifactId>
-  <version>another-test-5</version>
+  <version>1.0.2-SNAPSHOT</version>
   <description>Embedded PostgreSQL driver</description>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,12 @@
     <connection>scm:git:git://github.com/opentable/otj-pg-embedded.git</connection>
     <developerConnection>scm:git:git@github.com:opentable/otj-pg-embedded.git</developerConnection>
     <url>http://github.com/opentable/otj-pg-embedded</url>
-    <tag>otj-pg-embedded-another-test-4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-pg-embedded</artifactId>
-  <version>another-test-4</version>
+  <version>1.0.2-SNAPSHOT</version>
   <description>Embedded PostgreSQL driver</description>
 
   <properties>


### PR DESCRIPTION
* independent management of versions
* still uses basepom

Pro:
* Easier to support without dealing with our current SB 2/3 divergence

Con: 
* Some manual updates needed occasionally to dependencies.