### PR TITLE
Fix permission/ownership issues on Linux

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,14 +42,14 @@
     <project.build.targetJdk>11</project.build.targetJdk>
     <maven.compiler.target>${project.build.targetJdk}</maven.compiler.target>
     <project.build.systemJdk>${project.build.targetJdk}</project.build.systemJdk>
-    <dep.testcontainers.version>1.20.6</dep.testcontainers.version>
+    <dep.testcontainers.version>2.0.2</dep.testcontainers.version>
     <dep.postgres-jdbc.version>42.7.7</dep.postgres-jdbc.version>
     <dep.liquibase.version>4.23.1</dep.liquibase.version>
     <dep.slf4j.version>2.0.17</dep.slf4j.version>
     <dep.jackson.version>2.18.3</dep.jackson.version>
     <dep.flyway.version>10.20.1</dep.flyway.version>
     <dep.commons-lang.version>3.18.0</dep.commons-lang.version>
-    <dep.commons-compress.version>1.27.1</dep.commons-compress.version>
+    <dep.commons-compress.version>1.28.0</dep.commons-compress.version>
     <dep.junit.version>4.13.2</dep.junit.version>
     <dep.junit5.version>5.11.4</dep.junit5.version>
     <basepom.test.timeout>1800</basepom.test.timeout>
@@ -97,7 +97,11 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
       <version>${dep.commons-compress.version}</version>
-      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.20.0</version>
     </dependency>
 
     <dependency>
@@ -135,7 +139,7 @@
 
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
+      <artifactId>testcontainers-postgresql</artifactId>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
@@ -170,14 +174,14 @@
     <dependencies>
       <dependency>
         <groupId>org.testcontainers</groupId>
-        <artifactId>postgresql</artifactId>
+        <artifactId>testcontainers-postgresql</artifactId>
         <version>${dep.testcontainers.version}</version>
-       </dependency>
+      </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers</artifactId>
         <version>${dep.testcontainers.version}</version>
-       </dependency>
+      </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>

--- a/src/main/java/com/opentable/db/postgres/embedded/BindMount.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/BindMount.java
@@ -15,25 +15,24 @@ package com.opentable.db.postgres.embedded;
 
 import java.util.Objects;
 
-import org.testcontainers.containers.BindMode;
 
 public final class BindMount {
-    public static BindMount of(String localFile, String remoteFile, BindMode bindMode) {
-        return new BindMount(localFile, remoteFile, bindMode);
+    public static BindMount of(String localFile, String remoteFile, Integer fileMode) {
+        return new BindMount(localFile, remoteFile, fileMode);
     }
 
     private final String localFile;
     private final String remoteFile;
-    private final BindMode bindMode;
+    private final Integer fileMode;
 
-    private BindMount(String localFile, String remoteFile, BindMode bindMode) {
+    private BindMount(String localFile, String remoteFile, Integer fileMode) {
         this.localFile = localFile;
         this.remoteFile = remoteFile;
-        this.bindMode = bindMode == null ? BindMode.READ_ONLY : bindMode;
+        this.fileMode = fileMode;
     }
 
-    public BindMode getBindMode() {
-        return bindMode;
+    public Integer getfileMode() {
+        return fileMode;
     }
 
     public String getLocalFile() {
@@ -66,7 +65,7 @@ public final class BindMount {
         return "BindMount{" +
                 "localFile='" + localFile + '\'' +
                 ", remoteFile='" + remoteFile + '\'' +
-                ", bindMode=" + bindMode +
+                ", fileMode=" + fileMode +
                 '}';
     }
 }

--- a/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/EmbeddedPostgres.java
@@ -14,12 +14,14 @@
 package com.opentable.db.postgres.embedded;
 
 
-import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
+import static org.testcontainers.postgresql.PostgreSQLContainer.POSTGRESQL_PORT;
 
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -36,9 +38,8 @@ import javax.sql.DataSource;
 import org.postgresql.ds.PGSimpleDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -65,7 +66,7 @@ public class EmbeddedPostgres implements Closeable {
     static final String DOCKER_DEFAULT_TAG = "17-alpine";
     // Note you can override any of these defaults explicitly in the builder.
 
-    private final PostgreSQLContainer<?> postgreDBContainer;
+    private final PostgreSQLContainer postgreDBContainer;
 
     private final UUID instanceId = UUID.randomUUID();
 
@@ -81,7 +82,7 @@ public class EmbeddedPostgres implements Closeable {
         LOG.trace("Starting containers with image {}, pgConfig {}, localeConfig {}, bindMounts {}, pgStartupWait {}, dbName {} ", image,
                 postgresConfig, localeConfig, bindMounts, pgStartupWait, databaseName);
         image = image.asCompatibleSubstituteFor(POSTGRES);
-        this.postgreDBContainer = new PostgreSQLContainer<>(image)
+        this.postgreDBContainer = new PostgreSQLContainer(image)
                 .withDatabaseName(databaseName)
                 .withUsername(POSTGRES)
                 .withPassword(POSTGRES)
@@ -99,11 +100,21 @@ public class EmbeddedPostgres implements Closeable {
         postgreDBContainer.start();
     }
 
-    private void processBindMounts(PostgreSQLContainer<?> postgreDBContainer, Map<String, BindMount> bindMounts) {
-        bindMounts.values().stream()
-                .filter(f -> new File(f.getLocalFile()).exists())
-                .forEach(f -> postgreDBContainer.addFileSystemBind(f.getLocalFile(),
-                        f.getRemoteFile(), f.getBindMode()));
+    private void processBindMounts(PostgreSQLContainer postgreDBContainer, Map<String, BindMount> bindMounts) {
+        // Alpine images use postgres:70:70, others typically 999:999
+        final int uid = postgreDBContainer.getImage().get().contains("alpine") ? 70 : 999;
+        bindMounts.values()
+            .stream()
+            .filter(f -> new File(f.getLocalFile()).exists())
+            .forEach(f -> {
+                try {
+                    final byte[] content = Files.readAllBytes(Paths.get(f.getLocalFile()));
+                    final int mode = Optional.ofNullable(f.getfileMode()).orElse(0644);
+                    postgreDBContainer.withCopyToContainer(OwnedTransferable.of(content, mode, uid, uid), f.getRemoteFile());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
     }
 
     private List<String> createConfigOptions(final Map<String, String> postgresConfig) {
@@ -175,9 +186,10 @@ public class EmbeddedPostgres implements Closeable {
         }
      }
 
-     public String getHost() {
-        return postgreDBContainer.getContainerIpAddress();
-     }
+    public String getHost() {
+        return postgreDBContainer.getHost();
+    }
+
     public int getPort() {
         return postgreDBContainer.getMappedPort(POSTGRESQL_PORT);
     }
@@ -278,7 +290,7 @@ public class EmbeddedPostgres implements Closeable {
          * @return builder
          */
         public Builder setBindMount(String localFile, String remoteFile) {
-            return setBindMount(BindMount.of(localFile, remoteFile, BindMode.READ_ONLY));
+            return setBindMount(BindMount.of(localFile, remoteFile, null));
         }
 
         /**

--- a/src/main/java/com/opentable/db/postgres/embedded/OwnedTransferable.java
+++ b/src/main/java/com/opentable/db/postgres/embedded/OwnedTransferable.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.db.postgres.embedded;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.io.IOUtils;
+import org.testcontainers.images.builder.Transferable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.zip.Checksum;
+
+public interface OwnedTransferable extends Transferable {
+
+    default int getUid() {
+        return -1;
+    }
+
+    default int getGid() {
+        return -1;
+    }
+
+    static OwnedTransferable of(byte[] bytes, int fileMode) {
+        return of(bytes, fileMode, -1, -1);
+    }
+
+    static OwnedTransferable of(byte[] bytes, int fileMode, int uid, int gid) {
+        return new OwnedTransferable() {
+            @Override public long getSize() { return bytes.length; }
+            @Override public byte[] getBytes() { return bytes; }
+            @Override public void updateChecksum(Checksum c) { c.update(bytes, 0, bytes.length); }
+            @Override public int getFileMode() { return fileMode; }
+            @Override public int getUid() { return uid; }
+            @Override public int getGid() { return gid; }
+        };
+    }
+
+    @Override
+    default void transferTo(TarArchiveOutputStream tarArchiveOutputStream, String destination) {
+        TarArchiveEntry tarEntry = new TarArchiveEntry(destination);
+        tarEntry.setSize(getSize());
+        tarEntry.setMode(getFileMode());
+        if (getUid() >= 0) {
+            tarEntry.setUserId(getUid());
+        }
+        if (getGid() >= 0) {
+            tarEntry.setGroupId(getGid());
+        }
+        try {
+            tarArchiveOutputStream.putArchiveEntry(tarEntry);
+            IOUtils.write(getBytes(), tarArchiveOutputStream);
+            tarArchiveOutputStream.closeArchiveEntry();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Can't transfer " + getDescription(), e);
+        }
+    }
+}


### PR DESCRIPTION
* **Upgrade to Testcontainers 2.0.2**
* **Replace deprecated `addFileSystemBind` with `withCopyToContainer`**
  * For bind-mount-like behaviour we now copy config files into the container using `withCopyToContainer` instead of `addFileSystemBind`.
  * This follows Testcontainers’ recommendations and avoids host UID/GID quirks for mounted files.
* **Introduce `OwnedTransferable` helper**
  * Add a small wrapper around `Transferable` that lets us set file mode **and** uid/gid on tar entries.
  * Used for files that Postgres is strict about (e.g. key files), where ownership and `0600` permissions are required.


**Fix permission/ownership issues on Linux**

Previously, temp files created on the host were mounted into the container with the host UID and default `0600` mode. This happened to work on macOS (via Docker Desktop’s VM), but failed on Linux where Postgres runs as a non-root user.

We now:

* Copy files into the container using `OwnedTransferable`.
* Set modes appropriately (e.g. `0600` for key files, `0644` for config/certs).
* Set uid/gid based on the image variant (Alpine images use `postgres` as `70:70`, other images as `999:999`).

This makes the SSL/Vault integration tests pass reliably on both macOS and Linux without requiring root or special host permissions.