### PR TITLE
Correct typo in Flyway section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ public PreparedDbRule db =
         
         
 Please note: Recent versions of FLyway will probably hang if you have concurrent indexing. Use
-the features described in the 1.0.3 changelog to disable the broken lock feature. See the FlywarePreparerTest
+the features described in the 1.0.3 changelog to disable the broken lock feature. See the FlywayPreparerTest
 ```
 
 ##### Liquibase


### PR DESCRIPTION
Fix typo in README regarding FlywayPreparerTest.